### PR TITLE
refactor(generator): updated naming conventions

### DIFF
--- a/src/plugins/SoftwareGenerator/templates/test_bench/Makefile.tmpl
+++ b/src/plugins/SoftwareGenerator/templates/test_bench/Makefile.tmpl
@@ -23,7 +23,7 @@ COPY           = cp
 #
 #-------------------------------------------------------------------------------
 CPPSRC =
-CPPSRC += {{{sanitizedName}}}_GeneratedStates.cpp
+CPPSRC += {{{sanitizedName}}}_generated_states.cpp
 CPPSRC += {{{sanitizedName}}}_test.cpp
 
 #-------------------------------------------------------------------------------
@@ -113,10 +113,10 @@ $(CPPOBJ) : %.o : %.cpp
 
 {{{sanitizedName}}}_test:
 	@echo Compiling {{{sanitizedName}}}_test
-	g++ -o {{{sanitizedName}}}_test {{{sanitizedName}}}_test.cpp {{{sanitizedName}}}_GeneratedStates.cpp $(ALL_CFLAGS)
+	g++ -o {{{sanitizedName}}}_test {{{sanitizedName}}}_test.cpp {{{sanitizedName}}}_generated_states.cpp $(ALL_CFLAGS)
 {{{sanitizedName}}}_test_DEBUG:
 	@echo Compiling {{{sanitizedName}}}_test_DEBUG
-	g++ -o {{{sanitizedName}}}_test_DEBUG {{{sanitizedName}}}_test.cpp {{{sanitizedName}}}_GeneratedStates.cpp $(ALL_CFLAGS) $(DEBUG_DEFS)
+	g++ -o {{{sanitizedName}}}_test_DEBUG {{{sanitizedName}}}_test.cpp {{{sanitizedName}}}_generated_states.cpp $(ALL_CFLAGS) $(DEBUG_DEFS)
 run_{{{sanitizedName}}}_test: {{{sanitizedName}}}_test
 	@echo
 	@echo Running {{{sanitizedName}}}_test

--- a/src/plugins/SoftwareGenerator/templates/test_bench/test.cpp
+++ b/src/plugins/SoftwareGenerator/templates/test_bench/test.cpp
@@ -1,4 +1,4 @@
-#include "{{{sanitizedName}}}_GeneratedStates.hpp"
+#include "{{{sanitizedName}}}_generated_states.hpp"
 
 #include <string>
 #include <iostream>
@@ -26,12 +26,12 @@ int getUserSelection() {
   return s;
 }
 
-void makeEvent(StateMachine::{{{sanitizedName}}}::Root& root, int eventIndex) {
+void makeEvent(state_machine::{{{sanitizedName}}}::Root& root, int eventIndex) {
   if ( eventIndex < numEvents && eventIndex > -1 ) {
     switch (eventIndex) {
       {{#eventNames}}
       case {{{@index}}}: {
-        StateMachine::{{{../sanitizedName}}}::{{{.}}}EventData data{};
+        state_machine::{{{../sanitizedName}}}::{{{.}}}EventData data{};
         root.spawn_{{{.}}}_event(data);
         break;
       }
@@ -44,11 +44,11 @@ void makeEvent(StateMachine::{{{sanitizedName}}}::Root& root, int eventIndex) {
 
 int main( int argc, char** argv ) {
 
-  StateMachine::{{{sanitizedName}}}::GeneratedEventBase* e = nullptr;
+  state_machine::{{{sanitizedName}}}::GeneratedEventBase* e = nullptr;
   bool handled = false;
 
   // create the HFSM
-  StateMachine::{{{sanitizedName}}}::Root {{{sanitizedName}}}_root;
+  state_machine::{{{sanitizedName}}}::Root {{{sanitizedName}}}_root;
 
   // initialize the HFSM
   {{{sanitizedName}}}_root.initialize();

--- a/src/plugins/SoftwareGenerator/templates/uml/EndStateTempl.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/EndStateTempl.hpp
@@ -2,7 +2,7 @@
  * @brief This is the terminal END STATE for the HFSM, after which no
  *  events or other actions will be processed.
  */
-class {{{sanitizedName}}} : public StateMachine::StateBase {
+class {{{sanitizedName}}} : public state_machine::StateBase {
 public:
   explicit {{{sanitizedName}}} ( StateBase* parent ) : StateBase(parent) {}
   void entry ( void ) {}
@@ -10,6 +10,6 @@ public:
   void tick ( void ) {}
   // Simply returns true since the END STATE trivially handles all
   // events.
-  bool handleEvent ( StateMachine::EventBase* event ) { return true; }
+  bool handleEvent ( state_machine::EventBase* event ) { return true; }
   bool handleEvent ( GeneratedEventBase* event ) { return true; }
 };

--- a/src/plugins/SoftwareGenerator/templates/uml/GeneratedEventData.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/GeneratedEventData.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace StateMachine {
+namespace state_machine {
 namespace {{{sanitizedName}}} {
 
 {{#each eventNames}}
@@ -9,4 +9,4 @@ struct {{{.}}}EventData {
 {{/each}}
 
 }; // namespace {{{sanitizedName}}}
-}; // namespace StateMachine
+}; // namespace state_machine

--- a/src/plugins/SoftwareGenerator/templates/uml/GeneratedStates.cpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/GeneratedStates.cpp
@@ -2,7 +2,7 @@
 #include "{{{.}}}"
 {{/each}}
 
-using namespace StateMachine::{{{sanitizedName}}};
+using namespace state_machine::{{{sanitizedName}}};
 
 // User Definitions for the HFSM
 //::::{{{path}}}::::Definitions::::
@@ -53,7 +53,7 @@ bool Root::has_stopped(void) {
   bool reachedEnd = false;
   {{#END}}
   // Get the currently active leaf state
-  StateMachine::StateBase *activeLeaf = getActiveLeaf();
+  state_machine::StateBase *activeLeaf = getActiveLeaf();
   if (activeLeaf != nullptr && activeLeaf != this &&
       activeLeaf == static_cast<StateBase*>(&_root->{{{pointerName}}})) {
     reachedEnd = true;
@@ -66,7 +66,7 @@ bool Root::handleEvent(GeneratedEventBase *event) {
   bool handled = false;
 
   // Get the currently active leaf state
-  StateMachine::StateBase *activeLeaf = getActiveLeaf();
+  state_machine::StateBase *activeLeaf = getActiveLeaf();
 
   if (activeLeaf != nullptr && activeLeaf != this) {
     // have the active leaf handle the event, this will bubble up until

--- a/src/plugins/SoftwareGenerator/templates/uml/GeneratedStates.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/GeneratedStates.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "DeepHistoryState.hpp"
-#include "ShallowHistoryState.hpp"
-#include "StateBase.hpp"
+#include "state_base.hpp"
+#include "deep_history_state.hpp"
+#include "shallow_history_state.hpp"
 
 #include <deque>
 #include <string>
 #include <mutex>
 #include "magic_enum.hpp"
-#include "{{{sanitizedName}}}_EventData.hpp"
+#include "{{{sanitizedName}}}_event_data.hpp"
 
 #ifdef DEBUG_OUTPUT
 #include <iostream>
@@ -18,7 +18,7 @@
 //::::{{{path}}}::::Includes::::
 {{{ Includes }}}
 
-namespace StateMachine {
+namespace state_machine {
 
   namespace {{{sanitizedName}}} {
 
@@ -234,4 +234,4 @@ namespace StateMachine {
     }; // class Root
 
   }; // namespace {{{sanitizedName}}}
-}; // namespace StateMachine
+}; // namespace state_machine

--- a/src/plugins/SoftwareGenerator/templates/uml/Pointer.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/Pointer.hpp
@@ -2,9 +2,9 @@
 {{> PointerTemplHpp }}
 {{/each}}
 {{#if isDeepHistory}}
-StateMachine::DeepHistoryState {{{pointerName}}};
+state_machine::DeepHistoryState {{{pointerName}}};
 {{else if isShallowHistory}}
-StateMachine::ShallowHistoryState {{{pointerName}}};
+state_machine::ShallowHistoryState {{{pointerName}}};
 {{else if isState}}
 {{{fullyQualifiedName}}} {{{pointerName}}};
 {{/if}}

--- a/src/plugins/SoftwareGenerator/templates/uml/README.md
+++ b/src/plugins/SoftwareGenerator/templates/uml/README.md
@@ -25,7 +25,7 @@ executable C++ code.
 # States
 
 States get generated into their own class definitions which are
-instantiated once and which inherit from StateMachine::StateBase.  A
+instantiated once and which inherit from state_machine::StateBase.  A
 state is contained within the scope / namespace of its parent state.
 A state has a reference to which of its children is the currently
 active substate (if any exist) and a list of all its child substates.

--- a/src/plugins/SoftwareGenerator/templates/uml/StateTempl.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/StateTempl.hpp
@@ -1,6 +1,6 @@
 {{#if isState}}
 // Declaration for {{{fullyQualifiedName}}} : {{{path}}}
-class {{{sanitizedName}}} : public StateMachine::StateBase {
+class {{{sanitizedName}}} : public state_machine::StateBase {
 public:
   // User Declarations for the State
   //::::{{{path}}}::::Declarations::::

--- a/src/plugins/SoftwareGenerator/templates/uml/Templates.js
+++ b/src/plugins/SoftwareGenerator/templates/uml/Templates.js
@@ -1,9 +1,9 @@
 define(['bower/handlebars/handlebars.min',
         'underscore',
         'text!./static/magic_enum.hpp',
-        'text!./static/StateBase.hpp',
-        'text!./static/DeepHistoryState.hpp',
-        'text!./static/ShallowHistoryState.hpp',
+        'text!./static/state_base.hpp',
+        'text!./static/deep_history_state.hpp',
+        'text!./static/shallow_history_state.hpp',
         'text!./InternalEvent.tmpl',
         'text!./ExternalEvent.tmpl',
         'text!./ExternalTransition.tmpl',
@@ -44,9 +44,9 @@ define(['bower/handlebars/handlebars.min',
 
          var staticFiles = {
            'magic_enum.hpp': MagicEnumData,
-           'StateBase.hpp': StateBaseData,
-           'DeepHistoryState.hpp': DeepHistoryData,
-           'ShallowHistoryState.hpp': ShallowHistoryData,
+           'state_base.hpp': StateBaseData,
+           'deep_history_state.hpp': DeepHistoryData,
+           'shallow_history_state.hpp': ShallowHistoryData,
          };
 
          var Partials = {
@@ -73,9 +73,9 @@ define(['bower/handlebars/handlebars.min',
              "GeneratedStatesTemplCpp" ];
 
          var keyTemplates = {
-           'GeneratedEventDataTemplHpp': '{{{sanitizedName}}}_EventData.hpp',
-           'GeneratedStatesTemplHpp': '{{{sanitizedName}}}_GeneratedStates.hpp',
-           'GeneratedStatesTemplCpp': '{{{sanitizedName}}}_GeneratedStates.cpp',
+           'GeneratedEventDataTemplHpp': '{{{sanitizedName}}}_event_data.hpp',
+           'GeneratedStatesTemplHpp': '{{{sanitizedName}}}_generated_states.hpp',
+           'GeneratedStatesTemplCpp': '{{{sanitizedName}}}_generated_states.cpp',
          };
 
          var dependencies = {

--- a/src/plugins/SoftwareGenerator/templates/uml/static/deep_history_state.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/static/deep_history_state.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "StateBase.hpp"
+#include "state_base.hpp"
 
-namespace StateMachine {
+namespace state_machine {
 
   /**
    * @brief Deep History Pseudostates exist purely to re-implement the
@@ -24,4 +24,4 @@ namespace StateMachine {
       }
     }
   };
-};
+} // namespace state_machine

--- a/src/plugins/SoftwareGenerator/templates/uml/static/shallow_history_state.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/static/shallow_history_state.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "StateBase.hpp"
+#include "state_base.hpp"
 
-namespace StateMachine {
+namespace state_machine {
 
   /**
    * @brief Shallow History Pseudostates exist purely to re-implement
@@ -23,4 +23,4 @@ namespace StateMachine {
       }
     }
   };
-};
+} // namespace state_machine

--- a/src/plugins/SoftwareGenerator/templates/uml/static/state_base.hpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/static/state_base.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace StateMachine {
+namespace state_machine {
 
   // Base Class for Events, abstract so you never instantiate.
   class EventBase {
@@ -12,7 +12,7 @@ namespace StateMachine {
 
   /**
    * States contain other states and can consume generic
-   * StateMachine::EventBase objects if they have internal or external
+   * state_machine::EventBase objects if they have internal or external
    * transitions on those events and if those transitions' guards are
    * satisfied. Only one transition can consume an event in a given
    * state machine.
@@ -178,4 +178,4 @@ namespace StateMachine {
     StateBase *_parentState;
   }; // class StateBase
 
-}; // namespace StateMachine
+} // namespace state_machine


### PR DESCRIPTION
* Changed `StateMachine` namespace to be `state_machine` namespace
* Updated file names to be snake case for easier typing and reading
* Updated generators accordingly for hfsm and test bench