### PR TITLE
feat(generator): Update process model to check if event names are valid

### DIFF
--- a/src/common/checkModel.js
+++ b/src/common/checkModel.js
@@ -3,8 +3,12 @@ define([], function() {
   'use strict';
   return {
     stripRegex: /^([^\n]+)/gm,
-    badProperty: function(obj, prop) {
-      throw "ERROR: " +obj.path+" has invalid " +prop+": "+obj[prop];
+    badProperty: function(obj, prop, msg="") {
+      if (msg.length > 0) {
+        throw "ERROR: " +obj.path+" has invalid " +prop+": '"+obj[prop] + "'.\n " + msg;
+      } else {
+        throw "ERROR: " +obj.path+" has invalid " +prop+": '"+obj[prop] + "'.";
+      }
     },
     error: function(obj, str) {
       throw "ERROR: " +obj.path+" : "+str;
@@ -21,6 +25,11 @@ define([], function() {
       var sName = self.sanitizeString(obj.name);
       if ( !self.isValidString( sName ) )
        self.badProperty(obj, 'name');
+    },
+    checkEvent: function(obj) {
+      var self = this;
+      if ( self.hasEvent(obj) && !self.isValidString( obj.Event ) )
+        self.badProperty(obj, 'Event', 'Event must be a valid C++ Enum name (alphanumeric + underscore, starting with a letter)');
     },
     hasGuard: function( trans ) {
       return trans.Guard && trans.Guard.trim().length > 0;
@@ -64,6 +73,7 @@ define([], function() {
           topLevelObject = obj;
         }
         else if (obj.type == 'External Transition') {
+          self.checkEvent(obj);
           // checks: src, dst, Event, Guard,
           var src = model.objects[obj.pointers['src']],
               dst = model.objects[obj.pointers['dst']];
@@ -75,6 +85,7 @@ define([], function() {
           eventNames.push(obj.Event);
         }
         else if (obj.type == 'Local Transition') {
+          self.checkEvent(obj);
           // checks: src, dst, Event, Guard,
           var src = model.objects[obj.pointers['src']],
               dst = model.objects[obj.pointers['dst']];
@@ -95,6 +106,7 @@ define([], function() {
           eventNames.push(obj.Event);
         }
         else if (obj.type == 'Internal Transition') {
+          self.checkEvent(obj);
           // checks: event
           if ( !self.hasEvent( obj ) ) {
             self.error(obj, "INTERNAL TRANSITIONS MUST HAVE EVENTS");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update process model (used in software generator) to ensure that event names (if present) are valid c++ enum names since that is what they are generated as.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, software generator would work just fine if the `Event` for a transition was not a valid string (which must conform to the regex `/^[a-zA-Z_][a-zA-Z0-9_]+$/` to be a valid c++ enum name). This meant that you could get all the way to trying to compile / integrate your code before recognizing that your model was ill-formed. This PR fixes that by adding a check of the event names before generating the code. 

Note: this does not affect the simulator, which will fail to process transitions with invalid event names.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running on a model with invalid event names (e.g. a space in the name)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Error shown when the event is invalid:

![CleanShot 2024-05-22 at 17 39 52](https://github.com/finger563/webgme-hfsm/assets/213467/23eb6f8a-2f5a-4af6-a7fd-e630d27feb6f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
