### PR TITLE
fix(generator): Guard unhandled events switch cases with length check

### DIFF
--- a/src/common/processor.js
+++ b/src/common/processor.js
@@ -50,6 +50,7 @@ define(['./checkModel', 'underscore'], function(checkModel, _) {
     addBasicParams: function(obj) {
       obj.Substates = [];
       obj.UnhandledEvents = [];
+      obj.hasUnhandledEvents = false;
       obj.isRoot = false;
       obj.isExternalTransition = false;
       obj.isLocalTransition = false;
@@ -269,6 +270,7 @@ define(['./checkModel', 'underscore'], function(checkModel, _) {
           }));
         }
         obj.UnhandledEvents = _.difference( parent.UnhandledEvents, handledEventNames );
+        obj.hasUnhandledEvents = obj.UnhandledEvents.length > 0;
       }
       // recurse down from the top
       obj.Substates.map((s) => {
@@ -281,6 +283,7 @@ define(['./checkModel', 'underscore'], function(checkModel, _) {
         var obj = model.objects[path];
         if (obj.type == 'State Machine') {
           obj.UnhandledEvents = obj.eventNames;
+          obj.hasUnhandledEvents = obj.UnhandledEvents.length > 0;
           self.findUnhandledEvents(obj, model.objects);
         }
       });

--- a/src/plugins/SoftwareGenerator/templates/uml/StateTempl.cpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/StateTempl.cpp
@@ -42,11 +42,13 @@ bool Root::{{{fullyQualifiedName}}}::handleEvent ( GeneratedEventBase* event ) {
   // take care of all event types that this branch will not handle -
   // for more consistent run-time performnace
   switch ( event->get_type() ) {
+{{#if UnhandledEvents.length > 0}}
     {{#each UnhandledEvents}}
   case EventType::{{{.}}}:
     {{/each}}
     handled = true;
     break;
+{{/if}}
   default:
     handled = false;
     break;

--- a/src/plugins/SoftwareGenerator/templates/uml/StateTempl.cpp
+++ b/src/plugins/SoftwareGenerator/templates/uml/StateTempl.cpp
@@ -42,7 +42,7 @@ bool Root::{{{fullyQualifiedName}}}::handleEvent ( GeneratedEventBase* event ) {
   // take care of all event types that this branch will not handle -
   // for more consistent run-time performnace
   switch ( event->get_type() ) {
-{{#if UnhandledEvents.length > 0}}
+{{#if hasUnhandledEvents}}
     {{#each UnhandledEvents}}
   case EventType::{{{.}}}:
     {{/each}}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add `UnhandledEvents.length` via new `hasUnhandledEvents` check guarding the whole block to prevent emitting invalid / unreachable code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #189

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Generate and build the Complex seed / example project. Ensure it still works and the `ChildState3::Grand2` handle event is properly generated:

```c++
bool Root::State_2::ChildState3::Grand2::handleEvent ( GeneratedEventBase* event ) {
  bool handled = false;

  // take care of all event types that this branch will not handle -
  // for more consistent run-time performnace
  switch ( event->get_type() ) {
  default:
    handled = false;
    break;
  }
...
```

Ensure other states which have unhandled events are properly generated.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
