### PR TITLE
Deployment: MONGO_URI config, devcontainer/Codespaces, deployment + README docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "webgme-hfsm",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.devcontainer.yml"
+  ],
+  "service": "webgme-hfsm",
+  "workspaceFolder": "/usr/app",
+  "forwardPorts": [8081],
+  "portsAttributes": {
+    "8081": {
+      "label": "WebGME-HFSM",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "postStartCommand": "bash -c 'nohup npm start > /tmp/webgme-hfsm.log 2>&1 &'",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint"]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,29 @@
+# Devcontainer / Codespaces override for the base docker-compose.yml:
+#  - builds the image from the repo's Dockerfile (the base file only
+#    references a pre-built image)
+#  - mounts the checked-out workspace over /usr/app so edits are live
+#    (postCreateCommand repopulates node_modules inside the mount)
+#  - keeps the container alive; the server is started by
+#    postStartCommand (logs in /tmp/webgme-hfsm.log)
+services:
+  webgme-hfsm:
+    build:
+      # NOTE: with multiple -f compose files, relative paths resolve
+      # against the FIRST file's directory (the repo root), not this
+      # file's directory -- so these are '.' rather than '..'
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/usr/app:cached
+      # keep dependencies INSIDE the container: the workspace mount
+      # would otherwise shadow them with the host's (possibly
+      # non-Linux) builds. postCreateCommand populates these.
+      - hfsm-node-modules:/usr/app/node_modules
+      - hfsm-bower-components:/usr/app/bower_components
+    environment:
+      - NODE_ENV=docker
+    command: sleep infinity
+
+volumes:
+  hfsm-node-modules:
+  hfsm-bower-components:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Devcontainer metadata is well formed
         run: |
           # devcontainer.json permits // comments; strip them for jq
-          grep -v '^\s*//' .devcontainer/devcontainer.json > /tmp/devcontainer.json
+          grep -v '^[[:space:]]*//' .devcontainer/devcontainer.json > /tmp/devcontainer.json
           jq -e '.service == "webgme-hfsm"' /tmp/devcontainer.json > /dev/null
           jq -e '.forwardPorts | index(8081) != null' /tmp/devcontainer.json > /dev/null
           echo "devcontainer.json ok"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,67 @@ jobs:
           printf '1\n' | with_timeout 10 sample_code/Medium/Medium_test_DEBUG
           printf '1\n2\n0\n' | with_timeout 10 sample_code/Complex/Complex_test_DEBUG
 
+  deployment-config:
+    name: Deployment config and devcontainer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # config.docker.js is loaded by webgme's config validator, so a
+      # broken deployment config fails here rather than at deploy time
+      - name: Install config dependencies
+        run: npm install --no-save --no-package-lock --ignore-scripts webgme
+
+      - name: MONGO_URI is honored (cloud / Atlas deployments)
+        env:
+          NODE_ENV: docker
+          MONGO_URI: "mongodb+srv://user:pass@cluster.example.mongodb.net/webgme_hfsm?retryWrites=true"
+        run: |
+          node -e "
+            var c = require('./config');
+            var expected = process.env.MONGO_URI;
+            if (c.mongo.uri !== expected) {
+              throw new Error('MONGO_URI ignored: ' + c.mongo.uri);
+            }
+            console.log('mongo.uri honors MONGO_URI');
+          "
+
+      - name: Falls back to the compose service hostname
+        env:
+          NODE_ENV: docker
+        run: |
+          node -e "
+            var c = require('./config');
+            if (c.mongo.uri !== 'mongodb://mongo:27017/webgme_hfsm') {
+              throw new Error('unexpected fallback uri: ' + c.mongo.uri);
+            }
+            console.log('fallback uri ok');
+          "
+
+      - name: Devcontainer compose files merge and resolve
+        run: |
+          # relative paths in extra -f files resolve against the FIRST
+          # file's directory (a common footgun): assert the build
+          # context still lands inside the repo
+          ctx=$(docker compose -f docker-compose.yml \
+                  -f .devcontainer/docker-compose.devcontainer.yml \
+                  config --format json |
+                jq -r '.services["webgme-hfsm"].build.context')
+          echo "build context: $ctx"
+          test -f "$ctx/Dockerfile"
+
+      - name: Devcontainer metadata is well formed
+        run: |
+          # devcontainer.json permits // comments; strip them for jq
+          grep -v '^\s*//' .devcontainer/devcontainer.json > /tmp/devcontainer.json
+          jq -e '.service == "webgme-hfsm"' /tmp/devcontainer.json > /dev/null
+          jq -e '.forwardPorts | index(8081) != null' /tmp/devcontainer.json > /dev/null
+          echo "devcontainer.json ok"
+
   regen-simple:
     name: Simple sample regenerates from its model (no drift)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,21 @@ jobs:
             console.log('fallback uri ok');
           "
 
+      # the documented `docker compose up -d --build` must work on a
+      # FRESH checkout: without a build definition compose tries to
+      # PULL the image and fails for anyone who has not built it
+      - name: Base compose service builds the image locally
+        run: |
+          ctx=$(docker compose config --format json |
+                jq -r '.services["webgme-hfsm"].build.context // empty')
+          test -n "$ctx" || {
+            echo "webgme-hfsm has no build definition: 'docker compose up --build'"
+            echo "would try to PULL the image and fail on a fresh checkout"
+            exit 1
+          }
+          test -f "$ctx/Dockerfile"
+          echo "base build context: $ctx"
+
       - name: Devcontainer compose files merge and resolve
         run: |
           # relative paths in extra -f files resolve against the FIRST

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,56 @@ jobs:
           test -f "$ctx/Dockerfile"
           echo "base build context: $ctx"
 
+      # boot the real stack: this exercises component startup
+      # (including the UIRecorder router, which carries its own older
+      # MongoDB driver) rather than only checking config resolution
+      - name: Compose stack boots and serves
+        run: |
+          docker compose up -d --build
+          code=000
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/ || true)
+            [ "$code" = "200" ] && break
+            sleep 5
+          done
+          echo "http: $code"
+          docker compose logs webgme-hfsm > /tmp/server.log 2>&1 || true
+          test "$code" = "200" || { tail -40 /tmp/server.log; exit 1; }
+          grep -q "Server is listening" /tmp/server.log
+          # no component (e.g. UIRecorder) may fail during startup
+          if grep -niE "uirecorder.*(error|fail)" /tmp/server.log; then
+            echo "UIRecorder reported an error during startup"; exit 1
+          fi
+          docker compose down -v
+
+      # the same boot, but driven through MONGO_URI -- the variable
+      # cloud deployments set (and which UIRecorder also receives)
+      - name: Compose stack boots with MONGO_URI set
+        run: |
+          cat > /tmp/mongo-uri-override.yml <<'YAML'
+          services:
+            webgme-hfsm:
+              environment:
+                - "NODE_ENV=docker"
+                - "MONGO_URI=mongodb://mongo:27017/webgme_hfsm_citest"
+          YAML
+          docker compose -f docker-compose.yml -f /tmp/mongo-uri-override.yml up -d --build
+          code=000
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/ || true)
+            [ "$code" = "200" ] && break
+            sleep 5
+          done
+          echo "http: $code"
+          docker compose -f docker-compose.yml -f /tmp/mongo-uri-override.yml \
+            logs webgme-hfsm > /tmp/server-uri.log 2>&1 || true
+          test "$code" = "200" || { tail -40 /tmp/server-uri.log; exit 1; }
+          grep -q "webgme_hfsm_citest" /tmp/server-uri.log
+          if grep -niE "uirecorder.*(error|fail)" /tmp/server-uri.log; then
+            echo "UIRecorder reported an error during startup"; exit 1
+          fi
+          docker compose -f docker-compose.yml -f /tmp/mongo-uri-override.yml down -v
+
       - name: Devcontainer compose files merge and resolve
         run: |
           # relative paths in extra -f files resolve against the FIRST

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ the UML State Machine specification, see [Wikipedia UML State Machine](https://e
     - [Creating a HFSM](#creating-a-hfsm)
     - [Simulating a HFSM](#simulating-a-hfsm)
     - [Code Generation](#code-generation)
+        - [Standalone CLI Generation (no WebGME server)](#standalone-cli-generation-no-webgme-server)
         - [Test Bench Code](#test-bench-code)
+- [Deployment](#deployment)
+- [Validation & Testing](#validation--testing)
+- [Use Cases](#use-cases)
 - [Examples](#examples)
 
 <!-- markdown-toc end -->
@@ -57,11 +61,33 @@ the UML State Machine specification, see [Wikipedia UML State Machine](https://e
   * User can select which guards are true when transitions have guards
   * Currently active state tree branch shown including all event actions
   * Simulator informs the user if the model is not well formed
+* **Typed event payloads**: `Event` definitions with typed `Field`s,
+  available to guards and transition actions as `data.<field>` in
+  both the simulator and the generated code
+* **Direct variable access** in guards / actions / state code:
+  `someNumber < someValue` instead of `_root->someNumber <
+  _root->someValue` (zero-cost generated aliases; both spellings
+  work), with warnings when state declarations shadow machine
+  variables
+* Simulator **Variables and Events panels**: inspect and edit the
+  machine's variables and simulated event payload values while
+  stepping the model; guard prompts show the current values the
+  guards reference
 * In-model **collaborative code attribute editing** for the HFSM (using [the CodeEditor](https://github.com/finger563/webgme-codeeditor))
 * Model transformation plugin to produce executable **C++** code from
   the HFSM (*with more languages coming soon*!)
   * Disabled transitions are not generated
-  * Model is checked before being generated
+  * Model is checked before being generated (with extensive
+    validation and non-fatal warnings; see
+    [docs/VALIDATION.md](docs/VALIDATION.md))
+* **Standalone CLI** (`hfsm-gen`) running the same pipeline without a
+  WebGME server -- for CI, scripting, and testing (see
+  [docs/CLI.md](docs/CLI.md))
+* **Interop exports**: Mermaid, PlantUML, and SCXML per state machine
+* Precisely documented **execution semantics** shared by the
+  simulator and the generated code
+  ([docs/SEMANTICS.md](docs/SEMANTICS.md)), enforced in CI by golden
+  generation diffs, sanitizer builds, and execution-trace checks
 
 ## Description
 
@@ -429,6 +455,71 @@ Finished
 ```
 
 </p></details>
+
+## Deployment
+
+GitHub Pages cannot host the server (WebGME needs Node.js +
+websockets and a MongoDB); these options can. See
+[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full guide,
+including the checklist for public instances.
+
+**Local (docker compose)** -- the classic setup:
+
+```bash
+docker compose up -d --build   # webgme-hfsm + mongo
+# open http://localhost:8081
+```
+
+**GitHub Codespaces / devcontainer (one-click, zero infra)** -- the
+repo ships a [devcontainer](.devcontainer/) that builds the image,
+starts mongo, installs dependencies, and launches the server with
+port 8081 forwarded. Open the repo in a Codespace (or "Reopen in
+Container" locally) and the app comes up automatically (server logs
+in `/tmp/webgme-hfsm.log`).
+
+**Cloud hosting (always-on shared instance)** -- run the container on
+any host that runs Docker images (Fly.io, Render, Railway, ...) and
+point it at a managed database such as a free-tier MongoDB Atlas
+cluster via the `MONGO_URI` environment variable:
+
+```bash
+NODE_ENV=docker \
+MONGO_URI='mongodb+srv://user:pass@cluster.mongodb.net/webgme_hfsm?retryWrites=true' \
+npm start
+```
+
+(`MONGO_URI_UI_RECORDING` optionally stores UI recordings in a
+separate database; without `MONGO_URI` the container falls back to
+the compose service hostname `mongo`.)
+
+## Validation & Testing
+
+Models are validated before generation (structure, names, events,
+payloads, determinism -- see [docs/VALIDATION.md](docs/VALIDATION.md))
+and non-fatal warnings are surfaced in the CLI, the plugin, and the
+simulator. CI regenerates fixture models, byte-compares the output
+against committed goldens, compiles it warning-clean and under
+Address/UB sanitizers, and diffs scripted execution traces -- so the
+simulator's semantics, the documented semantics
+([docs/SEMANTICS.md](docs/SEMANTICS.md)), and the generated C++ can
+never silently drift apart. `sample_code/Simple` is regenerated from
+its committed model on every CI run with a zero-drift check.
+
+## Use Cases
+
+* **Embedded C++ state machines**: model, simulate, and generate
+  readable hierarchical state machines for firmware (ESP32 and
+  friends) -- typed event payloads, history states, and a
+  single-threaded dispatch contract with a thread-safe event queue
+* **Codegen in CI**: commit the model JSON next to your firmware and
+  regenerate with `hfsm-gen` on every build -- no WebGME server
+  required
+* **Living documentation**: export Mermaid diagrams straight into
+  READMEs / PRs (GitHub renders them natively), PlantUML for design
+  docs, SCXML for interchange with other statechart tools
+* **Design reviews & teaching**: collaborative editing plus in-model
+  simulation with variable / payload inspection makes state machine
+  behavior explorable without compiling anything
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -483,9 +483,10 @@ point it at a managed database such as a free-tier MongoDB Atlas
 cluster via the `MONGO_URI` environment variable:
 
 ```bash
-NODE_ENV=docker \
-MONGO_URI='mongodb+srv://user:pass@cluster.mongodb.net/webgme_hfsm?retryWrites=true' \
-npm start
+docker run -d -p 8081:8081 \
+  -e NODE_ENV=docker \
+  -e MONGO_URI='mongodb+srv://user:pass@cluster.mongodb.net/webgme_hfsm?retryWrites=true' \
+  webgme-hfsm
 ```
 
 (`MONGO_URI_UI_RECORDING` optionally stores UI recordings in a

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ including the checklist for public instances.
 **Local (docker compose)** -- the classic setup:
 
 ```bash
-docker compose up -d --build   # webgme-hfsm + mongo
+docker compose up -d --build   # builds the image, starts webgme + mongo
 # open http://localhost:8081
 ```
 

--- a/config/config.docker.js
+++ b/config/config.docker.js
@@ -3,11 +3,31 @@
 var config = require('./config.default'),
     validateConfig = require('webgme/config/validator');
 
-var mongo = 'mongodb://';
-if (process.env.MONGO_PORT_27017_TCP_ADDR !== undefined) {
-  mongo += process.env.MONGO_PORT_27017_TCP_ADDR + ':' + process.env.MONGO_PORT_27017_TCP_PORT;
+// Mongo connection resolution, in priority order:
+//
+//  1. MONGO_URI -- a complete connection string, e.g. a MongoDB Atlas
+//     `mongodb+srv://user:pass@cluster.mongodb.net/webgme_hfsm?...`
+//     URI. Use this when deploying the container to a cloud host
+//     (Fly.io / Render / Railway / ...) with a managed database.
+//     The UI-recording database defaults to the same URI; set
+//     MONGO_URI_UI_RECORDING to store recordings elsewhere.
+//  2. MONGO_PORT_27017_TCP_ADDR / _PORT -- legacy Docker link
+//     environment variables.
+//  3. The `mongo` hostname -- the docker-compose / devcontainer
+//     service name.
+var mongoUri, uiRecordingUri;
+if (process.env.MONGO_URI) {
+  mongoUri = process.env.MONGO_URI;
+  uiRecordingUri = process.env.MONGO_URI_UI_RECORDING || mongoUri;
 } else {
-  mongo += 'mongo:27017'
+  var mongo = 'mongodb://';
+  if (process.env.MONGO_PORT_27017_TCP_ADDR !== undefined) {
+    mongo += process.env.MONGO_PORT_27017_TCP_ADDR + ':' + process.env.MONGO_PORT_27017_TCP_PORT;
+  } else {
+    mongo += 'mongo:27017';
+  }
+  mongoUri = mongo + '/webgme_hfsm';
+  uiRecordingUri = mongo + '/webgme-ui-recording-data';
 }
 
 config.rest.components['UIRecorder'] = {
@@ -15,13 +35,13 @@ config.rest.components['UIRecorder'] = {
   mount: 'routers/UIRecorder',
     options: {
         mongo: {
-            uri: mongo+'/webgme-ui-recording-data',
+            uri: uiRecordingUri,
             options: {}
         }
     }
 };
 
-config.mongo.uri = mongo+'/webgme_hfsm';
+config.mongo.uri = mongoUri;
 
 validateConfig(config);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     ports:
       - "27017:27017"
   webgme-hfsm:
+    # build locally: without this, `docker compose up` tries to PULL
+    # `webgme-hfsm` from a registry and fails on a fresh checkout.
+    # `image:` names the image the build produces.
+    build: .
     image: webgme-hfsm
     depends_on:
       - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@
 #  $ docker-compose stop
 # To clean up containers/images/networks:
 #  $ docker system prune
-version: '3'
 services:
   mongo:
     image: mongo

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,93 @@
+# Deploying WebGME-HFSM
+
+WebGME-HFSM is a Node.js server (Express + websockets) backed by
+MongoDB, so it cannot run on a static host such as GitHub Pages. The
+options below cover local development, per-user cloud instances, and
+an always-on shared deployment.
+
+## 1. Local: docker compose
+
+```bash
+docker compose up -d --build   # webgme-hfsm + mongo
+# open http://localhost:8081
+docker compose logs -f webgme-hfsm
+docker compose down            # add -v to also drop the database
+```
+
+## 2. GitHub Codespaces / devcontainer
+
+The repo ships `.devcontainer/`, which composes the base
+`docker-compose.yml` (webgme + mongo) with an override that builds
+the image from the repo, mounts the workspace, installs
+dependencies, and starts the server with port 8081 forwarded and
+opened in the browser.
+
+- **Codespaces**: *Code → Codespaces → Create codespace*.
+- **Locally (VS Code)**: *Dev Containers: Reopen in Container*.
+
+Server logs land in `/tmp/webgme-hfsm.log` inside the container.
+Restart the server after changing server-side code:
+
+```bash
+pkill -f 'node app.js'; nohup npm start > /tmp/webgme-hfsm.log 2>&1 &
+```
+
+Two details worth knowing if you edit the devcontainer:
+
+- With multiple `-f` compose files, **relative paths resolve against
+  the first file's directory** (the repo root), which is why the
+  override uses `context: .` rather than `context: ..`.
+- `node_modules` and `bower_components` are **named volumes** so the
+  workspace mount cannot shadow the container's Linux-built
+  dependencies with the host's.
+
+## 3. Cloud hosting (always-on shared instance)
+
+Run the container image on any Docker host (Fly.io, Render, Railway,
+a VM, ...) and point it at a managed MongoDB (for example a free-tier
+[MongoDB Atlas](https://www.mongodb.com/atlas) M0 cluster).
+
+`config/config.docker.js` resolves the database in this order:
+
+| Priority | Source | Use |
+|---|---|---|
+| 1 | `MONGO_URI` | full connection string, including `mongodb+srv://` Atlas URIs |
+| 2 | `MONGO_PORT_27017_TCP_ADDR` / `_PORT` | legacy Docker links |
+| 3 | `mongo:27017` | the compose / devcontainer service hostname |
+
+```bash
+docker run -d -p 8081:8081 \
+  -e NODE_ENV=docker \
+  -e MONGO_URI='mongodb+srv://user:pass@cluster.mongodb.net/webgme_hfsm?retryWrites=true&w=majority' \
+  webgme-hfsm
+```
+
+`MONGO_URI_UI_RECORDING` optionally directs UI recordings to a
+separate database; it defaults to `MONGO_URI`.
+
+Checklist for a public deployment:
+
+- **Authentication is off by default.** WebGME's `config.default.js`
+  runs open with a `guest` user; enable
+  `config.authentication.enable` (and set a real JWT key pair) before
+  exposing an instance to the internet.
+- **Persist the blob storage.** Uploaded/generated artifacts live in
+  `blob-local-storage/` inside the container; mount a volume or
+  configure an external blob backend so they survive redeploys.
+- **Use a database user scoped to the app's databases**, and put the
+  instance behind TLS (most PaaS hosts terminate TLS for you).
+
+## 4. GitHub Pages
+
+Pages serves static files only -- no Node.js process, no websockets,
+no database -- so the editor/server cannot be hosted there. What
+Pages *can* serve today: the docs, and the generator's static
+outputs (Mermaid/PlantUML/SCXML exports and sample generated code)
+produced by `hfsm-gen`.
+
+A future static "playground" -- load a model JSON, view it, simulate
+it, generate code entirely client-side -- is tracked with the
+Rust/WASM work: the model format and the
+`resolveModel`/`checkModel`/`processor`/`declParser` modules are
+already browser-safe and WebGME-independent. Collaborative editing
+and persistent project storage would remain server-only.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -70,6 +70,19 @@ docker run -d -p 8081:8081 \
 `MONGO_URI_UI_RECORDING` optionally directs UI recordings to a
 separate database; it defaults to `MONGO_URI`.
 
+> **Note on the UI recorder.** `webgme-ui-replay` bundles its own
+> older MongoDB driver (2.2.x, pinned in `package-lock.json`) that
+> WebGME's main driver does not share. That version does understand
+> `mongodb+srv://` URIs -- it resolves the SRV record, defaults SSL
+> on, and reads TXT options -- and it ignores newer connection
+> options such as `retryWrites` rather than rejecting them. Still, it
+> is an old driver talking to a modern cluster, so if the recorder
+> ever fails to start against your provider (authentication
+> mechanisms are the most likely friction), point it at a plain
+> `mongodb://` database with `MONGO_URI_UI_RECORDING`, or drop the
+> `UIRecorder` component from `config/config.docker.js`. The rest of
+> the application is unaffected either way.
+
 Checklist for a public deployment:
 
 - **Anonymous access is on by default.** `config/config.default.js`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,10 +67,13 @@ separate database; it defaults to `MONGO_URI`.
 
 Checklist for a public deployment:
 
-- **Authentication is off by default.** WebGME's `config.default.js`
-  runs open with a `guest` user; enable
-  `config.authentication.enable` (and set a real JWT key pair) before
-  exposing an instance to the internet.
+- **Anonymous access is on by default.** `config/config.default.js`
+  sets `config.authentication.enable = true` *and*
+  `config.authentication.allowGuests = true`, so an instance is
+  effectively open: anyone reaching it acts as the `guest` user. Set
+  `config.authentication.allowGuests = false` (and configure real
+  users plus a proper JWT key pair) before exposing an instance to
+  the internet.
 - **Persist the blob storage.** Uploaded/generated artifacts live in
   `blob-local-storage/` inside the container; mount a volume or
   configure an external blob backend so they survive redeploys.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,11 +8,16 @@ an always-on shared deployment.
 ## 1. Local: docker compose
 
 ```bash
-docker compose up -d --build   # webgme-hfsm + mongo
+docker compose up -d --build   # builds the image, starts webgme + mongo
 # open http://localhost:8081
 docker compose logs -f webgme-hfsm
 docker compose down            # add -v to also drop the database
 ```
+
+The `webgme-hfsm` service carries both `build: .` and
+`image: webgme-hfsm`, so a fresh checkout builds the image locally
+rather than trying to pull it. (`build_and_run_docker.sh` does the
+same thing by hand and predates this; compose is the simpler path.)
 
 ## 2. GitHub Codespaces / devcontainer
 


### PR DESCRIPTION
## Summary

Makes the existing Docker image actually deployable somewhere other than a laptop, and brings the README up to date with everything that landed in #218.

**Cloud-hostable config** — `config.docker.js` now resolves Mongo from `MONGO_URI` first (full connection strings, including `mongodb+srv://` Atlas URIs), then the legacy Docker-link vars, then the compose hostname. That single change is what lets the image run on Fly.io / Render / Railway / a VM against a free-tier Atlas cluster. `MONGO_URI_UI_RECORDING` can split UI recordings into their own database.

**Devcontainer / Codespaces** — `.devcontainer/` composes the base `docker-compose.yml` with an override that builds from the repo, mounts the workspace, installs dependencies, and starts the server with 8081 forwarded and auto-opened. One click for collaborators; no infrastructure. Two footguns are handled and commented, because both bit during testing:
- with multiple `-f` compose files, **relative paths resolve against the first file's directory**, so the build context is `.`, not `..` (the intuitive spelling silently pointed outside the repo)
- `node_modules` / `bower_components` are **named volumes**, so the workspace mount cannot shadow the container's Linux-built dependencies with the host's

**Docs** — new `docs/DEPLOYMENT.md` covers all four options (compose, Codespaces, cloud + Atlas, and why Pages *cannot* host the server), with a checklist for public instances (auth is off by default, blob storage needs a volume, scope the DB user). The README gains **Deployment**, **Validation & Testing**, and **Use Cases** sections, plus feature entries for the event payloads, bare-name variable access, simulator Variables/Events panels, the `hfsm-gen` CLI, and the interop exports.

Also drops the obsolete `version` key from `docker-compose.yml` (it warned on every invocation).

## On GitHub Pages

Pages serves static files only — no Node process, no websockets, no database — so the editor/server can't live there. What it *can* serve today is docs and the generator's static outputs. A static playground (load a model, simulate, generate — all client-side) is tracked with the Rust/WASM work; the model format and the `resolveModel`/`checkModel`/`processor`/`declParser` modules are already browser-safe and WebGME-independent. Collaborative editing and project storage stay server-only.

## Test plan

- [x] New `deployment-config` CI job: asserts `MONGO_URI` is honored, the fallback URI is unchanged, the devcontainer compose merge resolves its build context **inside** the repo, and `devcontainer.json` keeps its service and forwarded port
- [x] Devcontainer verified end-to-end locally: built the merged stack, ran the `postCreateCommand`/`postStartCommand` as Codespaces would, and confirmed HTTP 200 from both inside and outside the container
- [x] Config verified both ways (`MONGO_URI` → Atlas URI; unset → `mongodb://mongo:27017/webgme_hfsm`)
- [x] Existing suites unaffected: 75 tests passing, generated-code compile + trace checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)