### PR TITLE
Simulator: form-based payload editing and per-spawn payload values

### DIFF
--- a/docs/SEMANTICS.md
+++ b/docs/SEMANTICS.md
@@ -126,6 +126,13 @@ even when no transition uses them yet (event-library semantics).
   unchanged.
 - A field cannot be named `data` (it would shadow the alias).
 
+In the simulator, an event's payload values are edited in the Events
+panel and used for every spawn of that event. Enabling **prompt for
+payload on spawn** instead asks for that spawn's values each time a
+payload-carrying event button is clicked (pre-filled from the panel,
+and written back to it when accepted), which is the quicker way to
+walk a guard through several payload values in one session.
+
 ## History
 
 - **Shallow history** re-enters the parent's most recent direct child

--- a/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.css
+++ b/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.css
@@ -1,0 +1,44 @@
+#formDialogTitle {
+    font-size: 20px;
+    margin: 0;
+}
+
+.formDialogRow {
+    margin-bottom: 10px;
+}
+
+.formDialogLabel {
+    display: block;
+    font-weight: bold;
+    font-size: 13px;
+    margin-bottom: 2px;
+}
+
+.formDialogOptional {
+    font-weight: normal;
+    font-style: italic;
+    color: #888;
+}
+
+.formDialogInput {
+    width: 100%;
+    font-family: monospace;
+    font-size: 13px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    padding: 4px 6px;
+}
+
+.formDialogHint {
+    font-size: 11px;
+    color: #888;
+    margin-top: 2px;
+}
+
+.formDialogError {
+    float: left;
+    color: #a94442;
+    font-size: 13px;
+    line-height: 34px;
+    text-align: left;
+}

--- a/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.html
+++ b/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.html
@@ -1,0 +1,16 @@
+<div class="attribute-details-dialog modal fade in" tabindex="-1" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 id="formDialogTitle"></h3>
+      </div>
+      <form id="formDialogForm" class="modal-body form-horizontal" role="form">
+      </form>
+      <div class="modal-footer">
+        <span id="formDialogError" class="formDialogError"></span>
+        <a href="#" class="btn btn-default btn-cancel">Cancel</a>
+        <a href="#" class="btn btn-primary btn-ok">OK</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js
@@ -30,12 +30,6 @@ define(['q',
 
          var FormDialog;
 
-         function escapeHtml(str) {
-           return String(str === undefined || str === null ? '' : str)
-             .replace(/&/g, '&amp;').replace(/</g, '&lt;')
-             .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-         }
-
          FormDialog = function () {
            this._dialog = $(FormDialogTemplate);
            this._dialog.appendTo($(document.body));
@@ -63,19 +57,32 @@ define(['q',
 
            $(self._title).text(title || 'Edit');
            self._form.empty();
+           // Keep direct references to the inputs instead of looking
+           // them up later by a selector built from the key: keys come
+           // from the model (field names), and building '#fd_' + key
+           // would break for any key containing CSS-selector special
+           // characters. A null-prototype map because '__proto__' is a
+           // valid C++ identifier and therefore a legal field name.
+           self._inputs = Object.create(null);
            self._fields.forEach(function(f) {
-             self._form.append([
-               '<div class="formDialogRow">',
-               '<label class="formDialogLabel" for="fd_' + escapeHtml(f.key) + '">',
-               escapeHtml(f.label || f.key),
-               (f.optional ? ' <span class="formDialogOptional">(optional)</span>' : ''),
-               '</label>',
-               '<input class="formDialogInput" id="fd_' + escapeHtml(f.key) + '"',
-               ' type="text" value="' + escapeHtml(f.value) + '"',
-               ' aria-label="' + escapeHtml(f.label || f.key) + '"/>',
-               (f.hint ? '<div class="formDialogHint">' + escapeHtml(f.hint) + '</div>' : ''),
-               '</div>',
-             ].join(''));
+             var row = $('<div class="formDialogRow"></div>');
+             var label = $('<label class="formDialogLabel"></label>')
+                 .text(f.label || f.key);
+             if (f.optional) {
+               label.append($('<span class="formDialogOptional"></span>')
+                            .text(' (optional)'));
+             }
+             var input = $('<input class="formDialogInput" type="text"/>')
+                 .attr('aria-label', f.label || f.key)
+                 .val(f.value === undefined || f.value === null ? '' : f.value);
+             // clicking the label focuses its own input (no id needed)
+             label.on('click', function() { input.focus(); });
+             row.append(label).append(input);
+             if (f.hint) {
+               row.append($('<div class="formDialogHint"></div>').text(f.hint));
+             }
+             self._form.append(row);
+             self._inputs[f.key] = input;
            });
 
            self._dialog.modal({ show: false });
@@ -107,9 +114,10 @@ define(['q',
 
          FormDialog.prototype._values = function () {
            var self = this;
-           var values = {};
+           var values = Object.create(null);
            self._fields.forEach(function(f) {
-             values[f.key] = self._form.find('#fd_' + f.key).first().val();
+             var input = self._inputs[f.key];
+             values[f.key] = input ? input.val() : '';
            });
            return values;
          };

--- a/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js
@@ -1,0 +1,163 @@
+/**
+ * A small modal form dialog: several labeled fields, OK / Cancel, and
+ * inline validation.
+ *
+ * Replaces chains of window.prompt() calls -- those cannot show the
+ * fields together, cannot validate without losing what was typed, and
+ * cannot be cancelled halfway without leaving the model half-edited.
+ *
+ * Usage:
+ *
+ *   var dlg = new FormDialog();
+ *   dlg.initialize('Add field', [
+ *     { key: 'name',    label: 'Name',    value: '' },
+ *     { key: 'type',    label: 'C++ type', value: 'int' },
+ *     { key: 'default', label: 'Default', value: '', optional: true },
+ *   ], function(values) {
+ *     // return an error string to keep the dialog open, or nothing
+ *     if (!isValid(values.name)) return '"' + values.name + '" is not valid';
+ *   });
+ *   dlg.show();
+ *   dlg.waitForValues().then(function(values) {
+ *     // values is undefined when cancelled
+ *   });
+ */
+define(['q',
+        'text!./FormDialog.html',
+        'css!./FormDialog.css'],
+       function(Q, FormDialogTemplate) {
+         'use strict';
+
+         var FormDialog;
+
+         function escapeHtml(str) {
+           return String(str === undefined || str === null ? '' : str)
+             .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+             .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+         }
+
+         FormDialog = function () {
+           this._dialog = $(FormDialogTemplate);
+           this._dialog.appendTo($(document.body));
+
+           this._title = this._dialog.find('#formDialogTitle').first();
+           this._form = this._dialog.find('#formDialogForm').first();
+           this._error = this._dialog.find('#formDialogError').first();
+           this._btnCancel = this._dialog.find('.btn-cancel').first();
+           this._btnOk = this._dialog.find('.btn-ok').first();
+         };
+
+         /**
+          * @param {string}   title
+          * @param {Array}    fields    [{key, label, value, hint, optional}]
+          * @param {function} validate  optional; receives the values
+          *                             object, returns an error string
+          *                             to keep the dialog open
+          */
+         FormDialog.prototype.initialize = function (title, fields, validate) {
+           var self = this;
+           self._fields = fields || [];
+           self._validate = validate;
+           self._deferred = Q.defer();
+           self._resolved = false;
+
+           $(self._title).text(title || 'Edit');
+           self._form.empty();
+           self._fields.forEach(function(f) {
+             self._form.append([
+               '<div class="formDialogRow">',
+               '<label class="formDialogLabel" for="fd_' + escapeHtml(f.key) + '">',
+               escapeHtml(f.label || f.key),
+               (f.optional ? ' <span class="formDialogOptional">(optional)</span>' : ''),
+               '</label>',
+               '<input class="formDialogInput" id="fd_' + escapeHtml(f.key) + '"',
+               ' type="text" value="' + escapeHtml(f.value) + '"',
+               ' aria-label="' + escapeHtml(f.label || f.key) + '"/>',
+               (f.hint ? '<div class="formDialogHint">' + escapeHtml(f.hint) + '</div>' : ''),
+               '</div>',
+             ].join(''));
+           });
+
+           self._dialog.modal({ show: false });
+
+           self._btnOk.on('click', function (event) {
+             event.stopPropagation();
+             event.preventDefault();
+             self._submit();
+           });
+           // Enter submits from any field
+           self._form.on('keydown', 'input', function (event) {
+             if (event.which === 13) {
+               event.preventDefault();
+               self._submit();
+             }
+           });
+           self._btnCancel.on('click', function (event) {
+             event.stopPropagation();
+             event.preventDefault();
+             self._close(undefined);
+           });
+           // dismissing the modal (backdrop / ESC / dismiss()) cancels
+           self._dialog.on('hidden.bs.modal', function () {
+             self._dialog.empty();
+             self._dialog.remove();
+             self._resolve(undefined);
+           });
+         };
+
+         FormDialog.prototype._values = function () {
+           var self = this;
+           var values = {};
+           self._fields.forEach(function(f) {
+             values[f.key] = self._form.find('#fd_' + f.key).first().val();
+           });
+           return values;
+         };
+
+         FormDialog.prototype._submit = function () {
+           var self = this;
+           var values = self._values();
+           if (self._validate) {
+             var err = self._validate(values);
+             if (err) {
+               // keep the dialog (and what was typed) in place
+               $(self._error).text(err);
+               return;
+             }
+           }
+           $(self._error).text('');
+           self._close(values);
+         };
+
+         FormDialog.prototype._close = function (values) {
+           var self = this;
+           self._pending = values;
+           self._dialog.modal('hide'); // triggers hidden.bs.modal
+           self._resolve(values);
+         };
+
+         FormDialog.prototype._resolve = function (values) {
+           var self = this;
+           if (self._resolved) {
+             return;
+           }
+           self._resolved = true;
+           self._deferred.resolve(values !== undefined ? values : self._pending);
+         };
+
+         /** Programmatically close (e.g. the model was switched). */
+         FormDialog.prototype.dismiss = function () {
+           this._dialog.modal('hide');
+         };
+
+         FormDialog.prototype.show = function () {
+           this._dialog.modal('show');
+         };
+
+         /** @return {Promise} values object, or undefined if cancelled */
+         FormDialog.prototype.waitForValues = function () {
+           return this._deferred.promise;
+         };
+
+         return FormDialog;
+       });

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.css
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.css
@@ -170,3 +170,17 @@
     color: #b58900;
     font-weight: bold;
 }
+
+/* per-spawn payload prompt toggle */
+.promptPayloadLabel {
+    display: block;
+    font-size: 11px;
+    font-weight: normal;
+    color: #555;
+    margin: 2px 6px 4px 6px;
+    cursor: pointer;
+}
+.promptPayloadLabel input {
+    margin-right: 4px;
+    vertical-align: middle;
+}

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.html
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.html
@@ -11,6 +11,10 @@
     <div class="simulatorTitle variablesTitle">Events
       <button type="button" id="addEventBtn" class="eventDefBtn" title="Add a new Event definition" aria-label="Add a new Event definition">+</button>
     </div>
+    <label class="promptPayloadLabel" title="Ask for payload values each time a payload-carrying event is spawned">
+      <input type="checkbox" id="promptPayloadToggle"/>
+      prompt for payload on spawn
+    </label>
     <div id="eventDefsPanel" class="variablesPanel">
     </div>
   </div>

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
@@ -5,6 +5,7 @@
 define(['js/util',
         'q',
         './Choice',
+        './FormDialog',
         'hfsm/declParser',
         'hfsm/checkModel',
         'bower/mustache.js/mustache.min',
@@ -16,6 +17,7 @@ define(['js/util',
        function(Util,
                 Q,
                 Choice,
+                FormDialog,
                 declParser,
                 checkModel,
                 mustache,
@@ -119,9 +121,20 @@ define(['js/util',
            // so a model switch can dismiss it, and the epoch counter
            // invalidates its (stale) resolution
            self._activeChoice = null;
+           // an open add/edit form dialog, dismissed on model switch
+           self._activeDialog = null;
            self._simEpoch = 0;
            var addEventBtn = self._el.find('#addEventBtn').first();
            addEventBtn.on('click', function() { self.onAddEvent(); });
+           // when on, clicking a payload-carrying event button asks for
+           // that spawn's values instead of using the panel's directly
+           self._promptForPayload = false;
+           var promptToggle = self._el.find('#promptPayloadToggle').first();
+           promptToggle.on('change', function() {
+             self._promptForPayload = $(this).is(':checked');
+             self.log('Payload prompt ' +
+                      (self._promptForPayload ? 'enabled' : 'disabled'));
+           });
 
            // STATE INFO DISPLAY
            self._stateInfo = self._el.find('#stateInfo').first();
@@ -577,6 +590,82 @@ define(['js/util',
            return metaIds.length ? metaIds[0] : null;
          };
 
+         /**
+          * Validation shared by the add / edit dialogs. Returns an
+          * error string (kept inline in the dialog) or undefined.
+          */
+         Simulator.prototype.validateEventName = function( name ) {
+           var self = this;
+           if (!name || !name.trim()) {
+             return 'An event name is required.';
+           }
+           name = name.trim();
+           if (!isValidEventName(name)) {
+             return '"' + name + '" must be a C++ identifier and not a ' +
+               'keyword or reserved generated name.';
+           }
+           if (self.getEventDefinition(name)) {
+             return 'An Event definition named "' + name + '" already exists.';
+           }
+           // names differing only by case collide in checkModel; an
+           // EXACT match with a used (but undefined) event is fine --
+           // that is how a used event gains its payload definition
+           var lower = name.toLowerCase();
+           var clash = self.getEventNames().filter(function(e) {
+             return e && e.trim().length;
+           }).filter(function(e) {
+             return e.toLowerCase() == lower && e != name;
+           });
+           if (clash.length) {
+             return '"' + name + '" differs only by case from the existing ' +
+               'event "' + clash[0] + '"; the model checker rejects that.';
+           }
+         };
+
+         Simulator.prototype.validateFieldValues = function( def, values, fieldId ) {
+           var name = (values.name || '').trim();
+           if (!name) {
+             return 'A field name is required.';
+           }
+           if (!isValidFieldName(name)) {
+             return '"' + name + '" must be a C++ identifier, not a keyword ' +
+               'or reserved generated name, and not "data".';
+           }
+           var duplicate = def.fields.filter(function(f) {
+             return f.name == name && f.id !== fieldId;
+           });
+           if (duplicate.length) {
+             return def.name + ' already has a field named "' + name + '".';
+           }
+           if (!(values.type || '').trim()) {
+             return 'A C++ type is required.';
+           }
+         };
+
+         /**
+          * Open a form dialog, tracking it so a model switch dismisses
+          * it (see reset()).
+          */
+         Simulator.prototype.openFormDialog = function( title, fields, validate ) {
+           var self = this;
+           var epoch = self._simEpoch;
+           var dialog = new FormDialog();
+           self._activeDialog = dialog;
+           dialog.initialize( title, fields, validate );
+           dialog.show();
+           return dialog.waitForValues().then(function(values) {
+             if (self._activeDialog === dialog) {
+               self._activeDialog = null;
+             }
+             // the model was switched while this dialog was open: its
+             // target objects may be gone, so do not act on it
+             if (epoch !== self._simEpoch) {
+               return undefined;
+             }
+             return values;
+           });
+         };
+
          Simulator.prototype.onAddEvent = function() {
            var self = this;
            var machineId = self.getTopLevelId();
@@ -586,43 +675,24 @@ define(['js/util',
                    'this State Machine -- is the Event meta type installed?');
              return;
            }
-           var name = window.prompt('New event name (C++ identifier):');
-           if (!name) return;
-           name = name.trim();
-           // same rules the generator enforces (identifier syntax,
-           // C++ keywords, reserved generated names)
-           if (!isValidEventName(name)) {
-             alert('"' + name + '" is not a valid event name ' +
-                   '(must be a C++ identifier and not a keyword / reserved name)!');
-             return;
-           }
-           if (self.getEventDefinition(name)) {
-             alert('An Event definition named "' + name + '" already exists!');
-             return;
-           }
-           // names differing only by case collide in checkModel; an
-           // EXACT match with a used (but undefined) event is fine --
-           // that is how a used event gains its payload definition
-           var lower = name.toLowerCase();
-           var caseClash = self.getEventNames().filter(function(e) {
-             return e && e.trim().length;
-           }).some(function(e) {
-             return e.toLowerCase() == lower && e != name;
-           });
-           if (caseClash) {
-             alert('"' + name + '" differs only by case from an existing ' +
-                   'event name; the model checker rejects that!');
-             return;
-           }
-           self._client.startTransaction();
-           var newId = self._client.createChild({
-             parentId: machineId,
-             baseId: metaId,
-           }, 'Adding Event definition ' + name);
-           self._client.setAttribute(newId, 'name', name,
-                                     'Naming new Event ' + name);
-           self._client.completeTransaction();
-           self.log('Added Event definition: ' + name);
+           self.openFormDialog('Add event', [
+             { key: 'name', label: 'Event name', value: '',
+               hint: 'C++ identifier; matches transitions using this event' },
+           ], function(values) {
+             return self.validateEventName( values.name );
+           }).then(function(values) {
+             if (!values) return; // cancelled
+             var name = values.name.trim();
+             self._client.startTransaction();
+             var newId = self._client.createChild({
+               parentId: machineId,
+               baseId: metaId,
+             }, 'Adding Event definition ' + name);
+             self._client.setAttribute(newId, 'name', name,
+                                       'Naming new Event ' + name);
+             self._client.completeTransaction();
+             self.log('Added Event definition: ' + name);
+           }).done();
          };
 
          Simulator.prototype.onAddField = function( def ) {
@@ -633,75 +703,65 @@ define(['js/util',
                    'definitions -- is the Field meta type installed?');
              return;
            }
-           var name = window.prompt('New field name for ' + def.name +
-                                    ' (C++ identifier):');
-           if (!name) return;
-           name = name.trim();
-           if (!isValidFieldName(name)) {
-             alert('"' + name + '" is not a valid field name ' +
-                   '(must be a C++ identifier, not a keyword / reserved name, not data)!');
-             return;
-           }
-           if (def.fields.some(function(f) { return f.name == name; })) {
-             alert(def.name + ' already has a field named "' + name + '"!');
-             return;
-           }
-           var type = window.prompt('C++ type for ' + name + ':', 'int');
-           if (!type || !type.trim()) return;
-           var dflt = window.prompt('Default value for ' + name +
-                                    ' (optional):', '');
-           if (dflt === null) return; // Cancel must not mutate the model
-           self._client.startTransaction();
-           var newId = self._client.createChild({
-             parentId: def.id,
-             baseId: metaId,
-           }, 'Adding Field ' + name);
-           self._client.setAttribute(newId, 'name', name);
-           self._client.setAttribute(newId, 'Type', type.trim());
-           if (dflt && dflt.trim()) {
-             self._client.setAttribute(newId, 'Default', dflt.trim());
-           }
-           self._client.completeTransaction();
-           self.log('Added Field ' + def.name + '.' + name +
-                    ' : ' + type.trim());
+           self.openFormDialog('Add field to ' + def.name, [
+             { key: 'name', label: 'Field name', value: '',
+               hint: 'available in guards / actions as data.<name>' },
+             { key: 'type', label: 'C++ type', value: 'int' },
+             { key: 'default', label: 'Default value', value: '',
+               optional: true, hint: 'initializer expression, e.g. 0 or "idle"' },
+           ], function(values) {
+             return self.validateFieldValues( def, values );
+           }).then(function(values) {
+             if (!values) return; // cancelled
+             var name = values.name.trim();
+             var type = values.type.trim();
+             var dflt = (values.default || '').trim();
+             self._client.startTransaction();
+             var newId = self._client.createChild({
+               parentId: def.id,
+               baseId: metaId,
+             }, 'Adding Field ' + name);
+             self._client.setAttribute(newId, 'name', name);
+             self._client.setAttribute(newId, 'Type', type);
+             if (dflt) {
+               self._client.setAttribute(newId, 'Default', dflt);
+             }
+             self._client.completeTransaction();
+             self.log('Added Field ' + def.name + '.' + name + ' : ' + type);
+           }).done();
          };
 
          Simulator.prototype.onEditField = function( def, field ) {
            var self = this;
-           var name = window.prompt('Field name:', field.name);
-           if (!name) return;
-           name = name.trim();
-           if (!isValidFieldName(name)) {
-             alert('"' + name + '" is not a valid field name ' +
-                   '(must be a C++ identifier, not a keyword / reserved name, not data)!');
-             return;
-           }
-           // renaming to an existing sibling field would create a
-           // model the generator rejects
-           var duplicate = def.fields.some(function(f) {
-             return f.name == name && f.id != field.id;
-           });
-           if (duplicate) {
-             alert(def.name + ' already has a field named "' + name + '"!');
-             return;
-           }
-           var type = window.prompt('C++ type:', field.type);
-           if (!type || !type.trim()) return;
-           var dflt = window.prompt('Default value (empty for none):',
-                                    field.default);
-           if (dflt === null) return;
-           self._client.startTransaction();
-           if (name != field.name) {
-             self._client.setAttribute(field.id, 'name', name);
-           }
-           if (type.trim() != field.type) {
-             self._client.setAttribute(field.id, 'Type', type.trim());
-           }
-           if (dflt.trim() != field.default) {
-             self._client.setAttribute(field.id, 'Default', dflt.trim());
-           }
-           self._client.completeTransaction();
-           self.log('Updated Field ' + def.name + '.' + name);
+           self.openFormDialog('Edit ' + def.name + '.' + field.name, [
+             { key: 'name', label: 'Field name', value: field.name },
+             { key: 'type', label: 'C++ type', value: field.type },
+             { key: 'default', label: 'Default value', value: field.default,
+               optional: true },
+           ], function(values) {
+             return self.validateFieldValues( def, values, field.id );
+           }).then(function(values) {
+             if (!values) return; // cancelled
+             var name = values.name.trim();
+             var type = values.type.trim();
+             var dflt = (values.default || '').trim();
+             if (name === field.name && type === field.type &&
+                 dflt === field.default) {
+               return; // nothing changed: no transaction, no log noise
+             }
+             self._client.startTransaction();
+             if (name !== field.name) {
+               self._client.setAttribute(field.id, 'name', name);
+             }
+             if (type !== field.type) {
+               self._client.setAttribute(field.id, 'Type', type);
+             }
+             if (dflt !== field.default) {
+               self._client.setAttribute(field.id, 'Default', dflt);
+             }
+             self._client.completeTransaction();
+             self.log('Updated Field ' + def.name + '.' + name);
+           }).done();
          };
 
          /**
@@ -721,6 +781,10 @@ define(['js/util',
            if (self._activeChoice) {
              try { self._activeChoice.dismiss(); } catch (e) { /* gone */ }
              self._activeChoice = null;
+           }
+           if (self._activeDialog) {
+             try { self._activeDialog.dismiss(); } catch (e) { /* gone */ }
+             self._activeDialog = null;
            }
            self._variableValues = null;
            self._machineVariables = Object.create(null);
@@ -1731,10 +1795,69 @@ define(['js/util',
            }
            else {
              self.updateActiveState();
-             if (self._activeState) {
+             if (!self._activeState) {
+               return;
+             }
+             // events carrying a payload can be spawned with per-spawn
+             // values (pre-filled from the Events panel) when the
+             // "prompt for payload" toggle is on; otherwise the panel
+             // values are used as-is
+             var def = self.getEventDefinition( eventName );
+             if (self._promptForPayload && def && def.fields.length) {
+               self.promptForPayload( def ).then(function(accepted) {
+                 if (!accepted) return; // cancelled: do not spawn
+                 self.updateActiveState();
+                 if (self._activeState) {
+                   self.handleEvent( eventName, self._activeState.id );
+                 }
+               }).done();
+             } else {
                self.handleEvent( eventName, self._activeState.id );
              }
            }
+         };
+
+         /**
+          * Ask for this spawn's payload values, pre-filled from the
+          * Events panel. Accepted values are written back to the panel
+          * (so they persist as the new defaults for the next spawn,
+          * matching how the panel already behaves).
+          *
+          * @return {Promise<boolean>} false when cancelled
+          */
+         Simulator.prototype.promptForPayload = function( def ) {
+           var self = this;
+           var stored = (self._eventFieldValues || {})[def.name] || {};
+           var fields = def.fields.map(function(f) {
+             var v = Object.prototype.hasOwnProperty.call(stored, f.name) ?
+                 stored[f.name] : f.default;
+             return {
+               key: f.name,
+               label: f.name + ' : ' + f.type,
+               value: v,
+               optional: true,
+               hint: f.description || undefined,
+             };
+           });
+           return self.openFormDialog('Spawn ' + def.name, fields)
+             .then(function(values) {
+               if (!values) return false;
+               if (!self._eventFieldValues) {
+                 self._eventFieldValues = Object.create(null);
+               }
+               if (!self._eventFieldValues[def.name]) {
+                 self._eventFieldValues[def.name] = Object.create(null);
+               }
+               Object.keys(values).forEach(function(k) {
+                 self._eventFieldValues[def.name][k] = values[k];
+               });
+               self.updateEventDefsPanel();
+               var shown = def.fields.map(function(f) {
+                 return f.name + '=' + values[f.name];
+               }).join(', ');
+               self.log('PAYLOAD: ' + def.name + ' { ' + shown + ' }');
+               return true;
+             });
          };
 
          Simulator.prototype.onShowEventButtonClick = function (e) {


### PR DESCRIPTION
## Summary

First item of the post-merge roadmap: making the event payload machinery pleasant to actually use.

**The problem.** Adding a payload field meant answering three `window.prompt()` dialogs in a row (name → type → default). You couldn't see the fields together, a rejected name threw away everything you'd typed, and cancelling midway had already partly applied the change — the earlier fix for that only patched the last prompt.

**`FormDialog`** — a small reusable modal: labeled fields, OK/Cancel, Enter-to-submit, and **inline validation that keeps the dialog and your input in place** when something is rejected. A typo now costs one keystroke instead of restarting the flow.

- add-event / add-field / edit-field all use it
- validation moves into `validateEventName` / `validateFieldValues` — unchanged in substance (identifier syntax, C++ keywords, reserved generated names, duplicates, case collisions) but reported *in place* rather than as an `alert()` that discards your work
- edit-field skips the transaction entirely when nothing changed
- an open dialog is tracked and dismissed on model switch, with its result ignored if the epoch moved — the same lifecycle the guard `Choice` dialog already had

**Per-spawn payloads** — a new *prompt for payload on spawn* toggle. With it on, clicking a payload-carrying event asks for that spawn's values, pre-filled from the Events panel and written back when accepted. That makes it quick to walk a guard through several payload values in one session. Off by default, so the existing panel-values flow is untouched.

## Test plan

- [x] Generator suites unaffected: 75 tests passing, generated-code compile + trace checks green
- [x] Rebuilt the container and confirmed the client actually receives the new modules — `FormDialog.js`, `.html`, and `.css` all serve 200 from the same route as the existing `Choice.js`, and the served `Simulator.js` has zero remaining `window.prompt` references
- [x] AMD dependency list and factory parameters verified aligned (a mismatch there shifts every module by one at runtime); trailing `css!` plugins correctly contribute no parameter
- [ ] **Click-through verification is outstanding** — I don't have browser automation in this session, so the dialogs have been verified structurally and by delivery, not by driving the UI. Worth exercising: add a field with a deliberately bad name (should stay open with an inline error and keep your input), cancel mid-edit (should leave the model untouched), and toggle payload-prompting on to spawn an event with one-off values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)