### PR TITLE
Static HFSM Playground: run the generator in the browser, no server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,36 @@ jobs:
           jq -e '.forwardPorts | index(8081) != null' /tmp/devcontainer.json > /dev/null
           echo "devcontainer.json ok"
 
+  web-playground:
+    name: Static playground builds and matches the CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install generator dependencies
+        run: >
+          npm install --no-save --no-package-lock --ignore-scripts
+          requirejs requirejs-text handlebars underscore
+
+      - name: Build the playground
+        run: ./scripts/build-web.sh
+
+      # asserts the build is self-contained (no CDN assets) and that
+      # the generator copied into it reproduces the goldens byte for
+      # byte -- i.e. the playground cannot drift from the CLI
+      - name: Verify the build
+        run: node scripts/verify-web-build.js
+
+      - name: Upload the playground
+        uses: actions/upload-artifact@v4
+        with:
+          name: hfsm-playground
+          path: dist/web
+
   regen-simple:
     name: Simple sample regenerates from its model (no drift)
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,13 @@ on:
       - 'src/plugins/SoftwareGenerator/templates/**'
       - 'test/fixtures/**'
       - 'scripts/build-web.sh'
+      # the verifier gates publication, so a fix to it must be able to
+      # rerun a failed deploy
+      - 'scripts/verify-web-build.js'
+      # dependency versions decide which CodeMirror / RequireJS /
+      # handlebars / underscore actually get vendored
+      - 'package.json'
+      - 'package-lock.json'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy playground to GitHub Pages
+
+# The WebGME editor itself cannot run on Pages (it needs Node and
+# MongoDB -- see docs/DEPLOYMENT.md). The static playground can: it
+# runs the model checker, code generator and exporters entirely in the
+# browser.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'src/common/**'
+      - 'src/plugins/SoftwareGenerator/templates/**'
+      - 'test/fixtures/**'
+      - 'scripts/build-web.sh'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# never cancel a half-finished deploy, but only one at a time
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install generator dependencies
+        run: >
+          npm install --no-save --no-package-lock --ignore-scripts
+          requirejs requirejs-text handlebars underscore
+
+      - name: Build the playground
+        run: ./scripts/build-web.sh
+
+      # do not publish something that has drifted from the CLI
+      - name: Verify the build
+        run: node scripts/verify-web-build.js
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/web
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ sample_code/*/*_test
 sample_code/*/*_test_DEBUG
 .DS_Store
 sample_code/*/hfsm_metadata.json
+dist/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ the UML State Machine specification, see [Wikipedia UML State Machine](https://e
     - [Code Generation](#code-generation)
         - [Standalone CLI Generation (no WebGME server)](#standalone-cli-generation-no-webgme-server)
         - [Test Bench Code](#test-bench-code)
+- [Playground (no install)](#playground-no-install)
 - [Deployment](#deployment)
 - [Validation & Testing](#validation--testing)
 - [Use Cases](#use-cases)
@@ -456,10 +457,33 @@ Finished
 
 </p></details>
 
+## Playground (no install)
+
+For turning a model into code without running a server at all, the
+repo ships a **static web playground**: load a model, validate it,
+generate the C++ (and Mermaid / PlantUML / SCXML), and download the
+result — entirely in the browser. No database, no authentication, no
+accounts, and it works offline.
+
+```bash
+npm run web    # build + serve on http://localhost:8080
+```
+
+It is also published to GitHub Pages on every push to `main`. It runs
+the *same* generator modules as the CLI and the WebGME plugin (copied
+into the build verbatim, with CI asserting the output stays
+byte-identical to the goldens), so what you get in the browser is
+what you get from `hfsm-gen`.
+
+It does not do modeling or simulation — those still need the WebGME
+editor below. See [docs/PLAYGROUND.md](docs/PLAYGROUND.md).
+
 ## Deployment
 
-GitHub Pages cannot host the server (WebGME needs Node.js +
-websockets and a MongoDB); these options can. See
+GitHub Pages cannot host the *editor* (WebGME needs Node.js +
+websockets and a MongoDB) — though it does host the
+[playground](#playground-no-install). For the full editor, these
+options work. See
 [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for the full guide,
 including the checklist for public instances.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -106,9 +106,13 @@ Pages *can* serve today: the docs, and the generator's static
 outputs (Mermaid/PlantUML/SCXML exports and sample generated code)
 produced by `hfsm-gen`.
 
-A future static "playground" -- load a model JSON, view it, simulate
-it, generate code entirely client-side -- is tracked with the
-Rust/WASM work: the model format and the
-`resolveModel`/`checkModel`/`processor`/`declParser` modules are
-already browser-safe and WebGME-independent. Collaborative editing
-and persistent project storage would remain server-only.
+The **static playground** now covers the server-free half of this:
+it loads a model, validates it, generates the C++, and produces the
+Mermaid / PlantUML / SCXML exports entirely client-side, and
+`.github/workflows/pages.yml` publishes it to Pages automatically.
+See [PLAYGROUND.md](PLAYGROUND.md).
+
+Editing, simulation, collaboration, and persistent project storage
+remain server-only -- they are built on WebGME's client APIs and its
+database. Bringing simulation to the browser is tracked with the
+Rust/WASM work.

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -1,0 +1,81 @@
+# HFSM Playground (static web app)
+
+A single-page app that runs the model checker, the C++ code
+generator, and the interop exporters **entirely in the browser** — no
+server, no database, no authentication, no accounts, no CDN.
+
+It exists because the full WebGME editor needs infrastructure
+(Node + MongoDB, see [DEPLOYMENT.md](DEPLOYMENT.md)) that is overkill
+when all you want is to turn a model into code, or to let someone try
+the generator without installing anything.
+
+## Running it
+
+```bash
+npm run web          # build + serve on http://localhost:8080
+```
+
+or, to build and serve separately:
+
+```bash
+npm run build:web                          # -> dist/web
+python3 -m http.server -d dist/web 8080
+```
+
+It must be served over http(s): the template loader uses XHR, so
+opening `index.html` from the filesystem will not work.
+
+The build output is self-contained (about half a megabyte) and can be
+dropped on any static host. `.github/workflows/pages.yml` publishes it
+to GitHub Pages on every push to `main` that touches the generator,
+the templates, or the page itself.
+
+## What it does
+
+- **Load** a model: pick a bundled example, open a `.json` file, drop
+  one anywhere on the page, or paste JSON directly.
+- **Validate**: model errors stop generation and are shown verbatim;
+  non-fatal warnings (shadowed variables, converted local
+  transitions, ...) are shown the way the CLI prints them.
+- **Generate**: the full C++ HFSM, optionally with the test bench,
+  plus Mermaid / PlantUML / SCXML exports.
+- **Take it away**: view any file, copy it, download one, or download
+  all of them.
+
+## What it does not do (yet)
+
+- **No editing or simulation.** Those live in the WebGME visualizer,
+  which is built on WebGME's client APIs (territories, transactions,
+  GME nodes). Bringing them across means decoupling the simulator
+  from those APIs — tracked with the Rust/WASM work.
+- **No persistence or collaboration.** Nothing leaves the browser;
+  there is nowhere to save to. That is the trade for needing no
+  infrastructure.
+
+## Why it cannot drift from the CLI
+
+The playground does not reimplement anything. `scripts/build-web.sh`
+copies `src/common/*` and the SoftwareGenerator templates into the
+build **verbatim**, and the page loads them with the same AMD module
+ids WebGME uses — so the browser runs the same
+`resolveModel → checkModel → processor → templates` pipeline as
+`hfsm-gen` and the WebGME plugin.
+
+`scripts/verify-web-build.js` enforces that in CI:
+
+1. every expected file is present in the build,
+2. the copied `src/common` modules are byte-identical to the sources,
+3. `index.html` loads no remote assets (so it works offline),
+4. loading the generator **out of the build output** and regenerating
+   every bundled example reproduces the committed goldens byte for
+   byte — the same goldens `test/generator.spec.js` checks.
+
+If someone changes a template, the goldens move, and this check moves
+with them; if the playground ever started producing different output
+from the CLI, step 4 fails.
+
+## Model format
+
+Same format the CLI takes — see [CLI.md](CLI.md). The bundled
+examples are the test fixtures themselves (`test/fixtures/*.json`),
+so the playground can only demo models that CI already covers.

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -83,6 +83,14 @@ If someone changes a template, the goldens move, and this check moves
 with them; if the playground ever started producing different output
 from the CLI, step 4 fails.
 
+## Namespace
+
+The **Namespace** box is an override and starts empty. Resolution
+matches the CLI exactly: an explicit value wins, otherwise the
+model's own top-level `namespace`, otherwise `state_machine`. After
+generating, the box's placeholder shows the namespace that was
+actually used, so an empty box is never ambiguous.
+
 ## Model format
 
 Same format the CLI takes — see [CLI.md](CLI.md). The bundled

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -42,6 +42,15 @@ the templates, or the page itself.
 - **Take it away**: view any file, copy it, download one, or download
   all of them.
 
+Both panes are [CodeMirror](https://codemirror.net/5/) editors, so the
+model is edited with JSON highlighting and line numbers, and generated
+files are shown highlighted by type: C++ (`.hpp` / `.cpp`), XML
+(`.scxml`), and shell (`Makefile`, an approximation — CodeMirror has
+no Makefile mode). Mermaid and PlantUML have no mode and render as
+plain text. Highlighting is strictly optional: if the editor library
+fails to load, the page falls back to a plain textarea and `<pre>` and
+generation still works.
+
 ## What it does not do (yet)
 
 - **No editing or simulation.** Those live in the WebGME visualizer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "chai": "^3.0.0",
+        "codemirror": "^5.65.21",
         "mocha": "^12.0.0",
         "rimraf": "^2.7.1"
       }
@@ -1509,6 +1510,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "codemirror": "^5.65.21",
     "mocha": "^12.0.0",
     "rimraf": "^2.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "node app.js",
     "test": "node ./node_modules/mocha/bin/mocha test/generator.spec.js test/declParser.spec.js",
     "test:generated": "./scripts/run_generated_tests.sh",
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "build:web": "./scripts/build-web.sh",
+    "web": "./scripts/build-web.sh && python3 -m http.server -d dist/web 8080",
+    "verify:web": "node scripts/verify-web-build.js"
   },
   "version": "1.6.0",
   "repository": {

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Assemble the static HFSM Playground into dist/web/.
+#
+# The result is fully self-contained: no server, no database, no
+# authentication, no CDN. It runs the SAME generator modules the CLI
+# and the WebGME plugin use, copied in verbatim, so there is no second
+# implementation to keep in sync.
+#
+# Usage:
+#   scripts/build-web.sh [outdir]     # default: dist/web
+#
+# Then serve it (the template loader uses XHR, so file:// will not do):
+#   python3 -m http.server -d dist/web 8080
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:-$REPO_ROOT/dist/web}"
+
+say() { printf '  %s\n' "$1"; }
+
+rm -rf "$OUT"
+mkdir -p "$OUT/vendor" "$OUT/examples" \
+         "$OUT/src/common" \
+         "$OUT/src/plugins/SoftwareGenerator"
+
+echo "building HFSM Playground -> $OUT"
+
+# 1. the page itself
+cp "$REPO_ROOT/web/index.html" "$REPO_ROOT/web/app.js" "$REPO_ROOT/web/app.css" "$OUT/"
+say "page"
+
+# 2. the generator: copied verbatim, never edited for the browser
+cp "$REPO_ROOT"/src/common/*.js "$OUT/src/common/"
+cp -R "$REPO_ROOT/src/plugins/SoftwareGenerator/templates" \
+      "$OUT/src/plugins/SoftwareGenerator/templates"
+say "generator ($(ls "$OUT/src/common" | wc -l | tr -d ' ') common modules + templates)"
+
+# 3. third-party runtime deps (vendored: the app must work offline)
+find_first() {
+  for candidate in "$@"; do
+    if [ -f "$candidate" ]; then printf '%s' "$candidate"; return 0; fi
+  done
+  echo "ERROR: none of these exist: $*" >&2
+  echo "Run 'npm install' (and 'bower install') first." >&2
+  exit 1
+}
+
+cp "$(find_first "$REPO_ROOT/node_modules/requirejs/require.js")" "$OUT/vendor/require.js"
+cp "$(find_first "$REPO_ROOT/node_modules/requirejs-text/text.js")" "$OUT/vendor/text.js"
+cp "$(find_first "$REPO_ROOT/bower_components/handlebars/handlebars.min.js" \
+                 "$REPO_ROOT/node_modules/handlebars/dist/handlebars.min.js")" \
+   "$OUT/vendor/handlebars.min.js"
+cp "$(find_first "$REPO_ROOT/node_modules/underscore/underscore-umd.js" \
+                 "$REPO_ROOT/node_modules/underscore/underscore.js")" \
+   "$OUT/vendor/underscore-umd.js"
+say "vendor (requirejs, text, handlebars, underscore)"
+
+# 4. example models -- the same fixtures the test suite generates from,
+#    so the playground can never demo something CI does not cover
+cp "$REPO_ROOT"/test/fixtures/*.json "$OUT/examples/"
+say "examples ($(ls "$OUT/examples" | wc -l | tr -d ' ') models)"
+
+echo "done. serve with:  python3 -m http.server -d $OUT 8080"

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -57,6 +57,25 @@ cp "$(find_first "$REPO_ROOT/node_modules/underscore/underscore-umd.js" \
    "$OUT/vendor/underscore-umd.js"
 say "vendor (requirejs, text, handlebars, underscore)"
 
+# CodeMirror for syntax highlighting -- editor for the model,
+# read-only views for the generated code. The directory layout is
+# preserved because the mode files resolve '../../lib/codemirror'
+# relative to themselves under AMD; flattening it would load the
+# library twice and the modes would register on the wrong copy.
+CM_SRC="$(dirname "$(find_first "$REPO_ROOT/node_modules/codemirror/lib/codemirror.js")")/.."
+mkdir -p "$OUT/vendor/codemirror/lib" \
+         "$OUT/vendor/codemirror/mode/javascript" \
+         "$OUT/vendor/codemirror/mode/clike" \
+         "$OUT/vendor/codemirror/mode/xml" \
+         "$OUT/vendor/codemirror/mode/shell"
+cp "$CM_SRC/lib/codemirror.js"  "$OUT/vendor/codemirror/lib/"
+cp "$CM_SRC/lib/codemirror.css" "$OUT/vendor/codemirror/lib/"
+cp "$CM_SRC/mode/javascript/javascript.js" "$OUT/vendor/codemirror/mode/javascript/"
+cp "$CM_SRC/mode/clike/clike.js"           "$OUT/vendor/codemirror/mode/clike/"
+cp "$CM_SRC/mode/xml/xml.js"               "$OUT/vendor/codemirror/mode/xml/"
+cp "$CM_SRC/mode/shell/shell.js"           "$OUT/vendor/codemirror/mode/shell/"
+say "codemirror (json, c++, xml, shell modes)"
+
 # 4. example models -- the same fixtures the test suite generates from,
 #    so the playground can never demo something CI does not cover
 cp "$REPO_ROOT"/test/fixtures/*.json "$OUT/examples/"

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -40,6 +40,13 @@ function must(file) {
 ['index.html', 'app.js', 'app.css',
  'vendor/require.js', 'vendor/text.js',
  'vendor/handlebars.min.js', 'vendor/underscore-umd.js',
+ // CodeMirror: the mode files resolve '../../lib/codemirror'
+ // relative to themselves, so this layout must be preserved
+ 'vendor/codemirror/lib/codemirror.js', 'vendor/codemirror/lib/codemirror.css',
+ 'vendor/codemirror/mode/javascript/javascript.js',
+ 'vendor/codemirror/mode/clike/clike.js',
+ 'vendor/codemirror/mode/xml/xml.js',
+ 'vendor/codemirror/mode/shell/shell.js',
  'src/common/resolveModel.js', 'src/common/processor.js',
  'src/common/checkModel.js', 'src/common/declParser.js',
  'src/common/exporters.js',
@@ -79,7 +86,9 @@ requirejs.config({
   paths: {
     'bower/handlebars/handlebars.min': path.join(dist, 'vendor/handlebars.min'),
     'underscore': path.join(dist, 'vendor/underscore-umd'),
-    'text': path.join(repoRoot, 'node_modules/requirejs-text/text'),
+    // from the BUILD, not node_modules: the point is to exercise the
+    // artifacts the browser will actually load
+    'text': path.join(dist, 'vendor/text'),
     'hfsm': path.join(dist, 'src/common'),
     'templates': path.join(dist, 'src/plugins/SoftwareGenerator/templates'),
   },
@@ -111,7 +120,9 @@ requirejs([
     Object.assign(artifacts, MetaTemplates.renderTestCode(model, NAMESPACE));
     Object.keys(model.objects).sort().forEach(function (p) {
       var obj = model.objects[p];
-      if (obj.type === 'State Machine') {
+      // State Machine AND Library -- hfsm-gen and web/app.js export
+      // both, so this must too or it could miss drift
+      if (obj.type === 'State Machine' || obj.type === 'Library') {
         artifacts[obj.sanitizedName + '.mmd'] = exporters.toMermaid(model, p);
         artifacts[obj.sanitizedName + '.puml'] = exporters.toPlantUML(model, p);
         artifacts[obj.sanitizedName + '.scxml'] = exporters.toSCXML(model, p);

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -57,17 +57,70 @@ function must(file) {
 
 // ---- 2. self-contained -------------------------------------------
 var html = fs.readFileSync(path.join(dist, 'index.html'), 'utf8');
-// only ASSET references matter here: an <a href> to the repo is fine,
-// a <script src> or <link href> pointing at a CDN is not
-var assetRefs = html.match(
-  /<(?:script|img)\b[^>]*\bsrc\s*=\s*"[^"]*"|<link\b[^>]*\bhref\s*=\s*"[^"]*"/gi) || [];
-var remote = assetRefs.filter(function (ref) {
-  return /["'](https?:)?\/\//.test(ref.replace(/^[^"]*"/, '"'));
-});
+// Only ASSET references matter here: an <a href> to the repo is fine,
+// a <script src> or <link href> pointing at a CDN is not. All three
+// quoting forms HTML allows are checked -- src='...', src="..." and
+// bare src=... -- or the guard would be trivially bypassable.
+var ATTR = '\\s*=\\s*(?:"([^"]*)"|\'([^\']*)\'|([^\\s>]+))';
+var assetRe = new RegExp(
+  '<(?:script|img)\\b[^>]*?\\bsrc' + ATTR +
+  '|<link\\b[^>]*?\\bhref' + ATTR, 'gi');
+var remote = [];
+var m;
+while ((m = assetRe.exec(html)) !== null) {
+  // whichever quoting form matched
+  var url = [m[1], m[2], m[3], m[4], m[5], m[6]].filter(function (v) {
+    return v !== undefined;
+  })[0] || '';
+  if (/^(?:https?:)?\/\//i.test(url.trim())) {
+    remote.push(m[0]);
+  }
+}
 if (remote.length) {
   fail('index.html loads remote assets (the build must work ' +
        'offline): ' + remote.join(', '));
 }
+
+// ---- 3a. vendored assets match their sources ----------------------
+// The node test loader cannot execute the browser build of
+// require.js, so validate the artifact itself: a truncated, stale or
+// swapped vendor file would otherwise pass every output check while
+// the published page fails to load.
+function firstExisting(candidates) {
+  for (var i = 0; i < candidates.length; i++) {
+    if (fs.existsSync(candidates[i])) return candidates[i];
+  }
+  return null;
+}
+[
+  ['vendor/require.js', ['node_modules/requirejs/require.js']],
+  ['vendor/text.js', ['node_modules/requirejs-text/text.js']],
+  ['vendor/handlebars.min.js', ['bower_components/handlebars/handlebars.min.js',
+                                'node_modules/handlebars/dist/handlebars.min.js']],
+  ['vendor/underscore-umd.js', ['node_modules/underscore/underscore-umd.js',
+                                'node_modules/underscore/underscore.js']],
+  ['vendor/codemirror/lib/codemirror.js', ['node_modules/codemirror/lib/codemirror.js']],
+  ['vendor/codemirror/lib/codemirror.css', ['node_modules/codemirror/lib/codemirror.css']],
+  ['vendor/codemirror/mode/javascript/javascript.js',
+   ['node_modules/codemirror/mode/javascript/javascript.js']],
+  ['vendor/codemirror/mode/clike/clike.js', ['node_modules/codemirror/mode/clike/clike.js']],
+  ['vendor/codemirror/mode/xml/xml.js', ['node_modules/codemirror/mode/xml/xml.js']],
+  ['vendor/codemirror/mode/shell/shell.js', ['node_modules/codemirror/mode/shell/shell.js']],
+].forEach(function (pair) {
+  var built = path.join(dist, pair[0]);
+  var source = firstExisting(pair[1].map(function (p) {
+    return path.join(repoRoot, p);
+  }));
+  if (!source) {
+    console.log('  (source for ' + pair[0] + ' not installed, skipping compare)');
+    return;
+  }
+  if (fs.readFileSync(built).compare(fs.readFileSync(source)) !== 0) {
+    fail(pair[0] + ' differs from its source (' +
+         path.relative(repoRoot, source) + ') -- the shipped asset is ' +
+         'not what the build intended');
+  }
+});
 
 // ---- 3. the copied generator matches the source -------------------
 fs.readdirSync(path.join(repoRoot, 'src', 'common'))
@@ -107,8 +160,11 @@ requirejs([
     var name = file.slice(0, -5);
     var golden = path.join(goldenDir, name);
     if (!fs.existsSync(golden)) {
-      console.log('  (no goldens for ' + name + ', skipping output check)');
-      return;
+      // publishing an example nothing verifies would quietly break
+      // the invariant this script exists to enforce
+      fail('bundled example "' + name + '" has no goldens in ' +
+           path.relative(repoRoot, goldenDir) + ' -- every example ' +
+           'must be covered (add a fixture golden, or stop bundling it)');
     }
     var model = JSON.parse(
       fs.readFileSync(path.join(dist, 'examples', file), 'utf8'));
@@ -129,12 +185,27 @@ requirejs([
       }
     });
 
-    fs.readdirSync(golden).forEach(function (gf) {
-      if (IGNORED.indexOf(gf) > -1) return;
+    // compare the file SETS first: an unexpected EXTRA artifact is
+    // drift too, and checking only golden -> artifact would miss it
+    var goldenNames = fs.readdirSync(golden).filter(function (gf) {
+      return IGNORED.indexOf(gf) === -1;
+    }).sort();
+    var artifactNames = Object.keys(artifacts).filter(function (af) {
+      return IGNORED.indexOf(af) === -1;
+    }).sort();
+    if (goldenNames.join('\n') !== artifactNames.join('\n')) {
+      var extra = artifactNames.filter(function (n) {
+        return goldenNames.indexOf(n) === -1;
+      });
+      var missing = goldenNames.filter(function (n) {
+        return artifactNames.indexOf(n) === -1;
+      });
+      fail(name + ': generated file set differs from the goldens' +
+           (extra.length ? '; unexpected: ' + extra.join(', ') : '') +
+           (missing.length ? '; missing: ' + missing.join(', ') : ''));
+    }
+    goldenNames.forEach(function (gf) {
       var expected = fs.readFileSync(path.join(golden, gf), 'utf8');
-      if (artifacts[gf] === undefined) {
-        fail(name + ': the build did not generate ' + gf);
-      }
       if (artifacts[gf] !== expected) {
         fail(name + ': ' + gf + ' generated from the build differs from ' +
              'the golden -- the playground has drifted from the CLI');

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Verify the assembled static playground.
+ *
+ * The playground's value rests on one property: it runs the SAME
+ * generator as the CLI, so its output cannot drift. This checks that
+ * by loading the modules *out of the build output* and regenerating
+ * every fixture, comparing against the committed goldens -- the same
+ * files test/generator.spec.js checks.
+ *
+ * It also asserts the build is self-contained (no CDN / absolute
+ * references), because "works offline / hosts anywhere" is the whole
+ * point of shipping it this way.
+ *
+ * Usage: node scripts/verify-web-build.js [dist/web]
+ */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var repoRoot = path.resolve(__dirname, '..');
+var dist = process.argv[2] || path.join(repoRoot, 'dist', 'web');
+var goldenDir = path.join(repoRoot, 'test', 'goldens');
+var NAMESPACE = 'state_machine';
+var IGNORED = ['hfsm_metadata.json'];
+
+function fail(msg) {
+  console.error('verify-web-build: ' + msg);
+  process.exit(1);
+}
+
+function must(file) {
+  var p = path.join(dist, file);
+  if (!fs.existsSync(p)) fail('missing from build: ' + file);
+  return p;
+}
+
+// ---- 1. structure -------------------------------------------------
+['index.html', 'app.js', 'app.css',
+ 'vendor/require.js', 'vendor/text.js',
+ 'vendor/handlebars.min.js', 'vendor/underscore-umd.js',
+ 'src/common/resolveModel.js', 'src/common/processor.js',
+ 'src/common/checkModel.js', 'src/common/declParser.js',
+ 'src/common/exporters.js',
+ 'src/plugins/SoftwareGenerator/templates/MetaTemplates.js',
+ 'src/plugins/SoftwareGenerator/templates/uml/Templates.js',
+ 'src/plugins/SoftwareGenerator/templates/uml/static/magic_enum.hpp',
+].forEach(must);
+
+// ---- 2. self-contained -------------------------------------------
+var html = fs.readFileSync(path.join(dist, 'index.html'), 'utf8');
+// only ASSET references matter here: an <a href> to the repo is fine,
+// a <script src> or <link href> pointing at a CDN is not
+var assetRefs = html.match(
+  /<(?:script|img)\b[^>]*\bsrc\s*=\s*"[^"]*"|<link\b[^>]*\bhref\s*=\s*"[^"]*"/gi) || [];
+var remote = assetRefs.filter(function (ref) {
+  return /["'](https?:)?\/\//.test(ref.replace(/^[^"]*"/, '"'));
+});
+if (remote.length) {
+  fail('index.html loads remote assets (the build must work ' +
+       'offline): ' + remote.join(', '));
+}
+
+// ---- 3. the copied generator matches the source -------------------
+fs.readdirSync(path.join(repoRoot, 'src', 'common'))
+  .filter(function (f) { return f.slice(-3) === '.js'; })
+  .forEach(function (f) {
+    var a = fs.readFileSync(path.join(repoRoot, 'src', 'common', f), 'utf8');
+    var b = fs.readFileSync(path.join(dist, 'src', 'common', f), 'utf8');
+    if (a !== b) fail('src/common/' + f + ' differs from the build copy');
+  });
+
+// ---- 4. same output as the CLI / goldens --------------------------
+var requirejs = require('requirejs');
+requirejs.config({
+  baseUrl: dist,
+  nodeRequire: require,
+  paths: {
+    'bower/handlebars/handlebars.min': path.join(dist, 'vendor/handlebars.min'),
+    'underscore': path.join(dist, 'vendor/underscore-umd'),
+    'text': path.join(repoRoot, 'node_modules/requirejs-text/text'),
+    'hfsm': path.join(dist, 'src/common'),
+    'templates': path.join(dist, 'src/plugins/SoftwareGenerator/templates'),
+  },
+});
+
+requirejs([
+  'hfsm/resolveModel', 'hfsm/processor', 'hfsm/exporters',
+  'templates/MetaTemplates',
+], function (resolveModel, processor, exporters, MetaTemplates) {
+  var fixtures = fs.readdirSync(path.join(dist, 'examples'))
+      .filter(function (f) { return f.slice(-5) === '.json'; });
+  if (!fixtures.length) fail('no example models were bundled');
+
+  var checked = 0;
+  fixtures.forEach(function (file) {
+    var name = file.slice(0, -5);
+    var golden = path.join(goldenDir, name);
+    if (!fs.existsSync(golden)) {
+      console.log('  (no goldens for ' + name + ', skipping output check)');
+      return;
+    }
+    var model = JSON.parse(
+      fs.readFileSync(path.join(dist, 'examples', file), 'utf8'));
+    resolveModel.resolve(model);
+    processor.processModel(model);
+
+    var artifacts = {};
+    Object.assign(artifacts, MetaTemplates.renderHFSM(model, NAMESPACE));
+    Object.assign(artifacts, MetaTemplates.renderTestCode(model, NAMESPACE));
+    Object.keys(model.objects).sort().forEach(function (p) {
+      var obj = model.objects[p];
+      if (obj.type === 'State Machine') {
+        artifacts[obj.sanitizedName + '.mmd'] = exporters.toMermaid(model, p);
+        artifacts[obj.sanitizedName + '.puml'] = exporters.toPlantUML(model, p);
+        artifacts[obj.sanitizedName + '.scxml'] = exporters.toSCXML(model, p);
+      }
+    });
+
+    fs.readdirSync(golden).forEach(function (gf) {
+      if (IGNORED.indexOf(gf) > -1) return;
+      var expected = fs.readFileSync(path.join(golden, gf), 'utf8');
+      if (artifacts[gf] === undefined) {
+        fail(name + ': the build did not generate ' + gf);
+      }
+      if (artifacts[gf] !== expected) {
+        fail(name + ': ' + gf + ' generated from the build differs from ' +
+             'the golden -- the playground has drifted from the CLI');
+      }
+      checked++;
+    });
+  });
+
+  console.log('verify-web-build: OK (' + fixtures.length + ' models, ' +
+              checked + ' files identical to the goldens)');
+}, function (err) {
+  fail('could not load the generator from the build: ' + err.message);
+});

--- a/web/app.css
+++ b/web/app.css
@@ -74,6 +74,21 @@ button.primary { background: #1f883d; border-color: #1a7f37; color: #fff; font-w
 button.primary:hover { background: #1a7f37; }
 .filebtn { position: relative; overflow: hidden; display: inline-block; }
 .filebtn input { position: absolute; inset: 0; opacity: 0; cursor: pointer; width: 100%; }
+/* the real input is transparent, so its focus ring is invisible:
+   surface focus on the visible label instead, or keyboard users
+   cannot tell where they are */
+.filebtn:focus-within {
+    outline: 2px solid #0969da;
+    outline-offset: 1px;
+    background: #eaeef2;
+}
+/* same for every other control, using the browser default ring */
+button:focus-visible,
+select:focus-visible,
+.opt input:focus-visible {
+    outline: 2px solid #0969da;
+    outline-offset: 1px;
+}
 
 .editor-wrap {
     flex: 1 1 auto;

--- a/web/app.css
+++ b/web/app.css
@@ -75,6 +75,14 @@ button.primary:hover { background: #1a7f37; }
 .filebtn { position: relative; overflow: hidden; display: inline-block; }
 .filebtn input { position: absolute; inset: 0; opacity: 0; cursor: pointer; width: 100%; }
 
+.editor-wrap {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
 #modelInput {
     flex: 1 1 auto;
     min-height: 0;
@@ -86,6 +94,19 @@ button.primary:hover { background: #1a7f37; }
     resize: none;
     outline: none;
 }
+
+/* CodeMirror fills whichever pane it was mounted into */
+.editor-wrap .CodeMirror,
+.viewer-body .CodeMirror {
+    flex: 1 1 auto;
+    height: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.viewer-body .CodeMirror { border: 0; }
+/* read-only view: hide the blinking cursor, keep selection usable */
+.viewer-body .CodeMirror-cursors { visibility: hidden !important; }
 
 .pane-foot {
     display: flex;
@@ -180,13 +201,14 @@ button.primary:hover { background: #1a7f37; }
 .viewer-body {
     flex: 1 1 auto;
     margin: 0;
-    padding: 10px;
     overflow: auto;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
     line-height: 1.5;
     white-space: pre;
     min-height: 0;
+    display: flex;
+    flex-direction: column;
 }
 
 /* the hidden attribute must win over the display below, or the

--- a/web/app.css
+++ b/web/app.css
@@ -1,0 +1,209 @@
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px;
+    color: #24292f;
+    background: #f6f8fa;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.topbar {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 10px 16px;
+    background: #24292f;
+    color: #fff;
+    flex: 0 0 auto;
+}
+.brand { font-weight: 600; font-size: 16px; }
+.tagline { color: #b9c0c8; font-size: 12px; flex: 1 1 auto; }
+.repo { color: #9dc7ff; text-decoration: none; font-size: 12px; }
+.repo:hover { text-decoration: underline; }
+
+.layout {
+    flex: 1 1 auto;
+    display: grid;
+    grid-template-columns: minmax(320px, 38%) 1fr;
+    gap: 12px;
+    padding: 12px;
+    min-height: 0;
+}
+@media (max-width: 860px) {
+    .layout { grid-template-columns: 1fr; grid-template-rows: minmax(200px, 40%) 1fr; }
+}
+
+.pane {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    overflow: hidden;
+}
+.pane-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.pane-head h2 { margin: 0; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: #57606a; }
+.controls { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+
+button, select, .filebtn {
+    font: inherit;
+    font-size: 13px;
+    padding: 4px 10px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #f6f8fa;
+    color: #24292f;
+    cursor: pointer;
+}
+button:hover:not(:disabled), .filebtn:hover { background: #eaeef2; }
+button:disabled { opacity: .5; cursor: default; }
+button.primary { background: #1f883d; border-color: #1a7f37; color: #fff; font-weight: 600; }
+button.primary:hover { background: #1a7f37; }
+.filebtn { position: relative; overflow: hidden; display: inline-block; }
+.filebtn input { position: absolute; inset: 0; opacity: 0; cursor: pointer; width: 100%; }
+
+#modelInput {
+    flex: 1 1 auto;
+    min-height: 0;
+    border: 0;
+    padding: 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    resize: none;
+    outline: none;
+}
+
+.pane-foot {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 10px;
+    border-top: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.opt { font-size: 12px; color: #57606a; display: flex; align-items: center; gap: 6px; }
+.opt input[type="text"] {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    padding: 3px 6px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    width: 150px;
+}
+.opt.checkbox { cursor: pointer; }
+.pane-foot .primary { margin-left: auto; }
+
+.status { font-size: 12px; color: #57606a; }
+.status-ok { color: #1a7f37; }
+.status-warn { color: #9a6700; }
+.status-error { color: #cf222e; font-weight: 600; }
+
+.diagnostics {
+    padding: 8px 10px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    max-height: 30%;
+    overflow: auto;
+    border-bottom: 1px solid #d0d7de;
+    white-space: pre-wrap;
+}
+.diagnostics-error { background: #ffebe9; color: #82071e; }
+.diagnostics-warn { background: #fff8c5; color: #7d4e00; }
+.diag-line + .diag-line { margin-top: 6px; }
+
+.results { flex: 1 1 auto; display: flex; min-height: 0; }
+.filelist {
+    flex: 0 0 240px;
+    margin: 0;
+    padding: 6px;
+    list-style: none;
+    overflow: auto;
+    border-right: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.filelist-group {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: #57606a;
+    margin: 8px 4px 2px;
+}
+.filelist-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: 0;
+    background: transparent;
+    border-radius: 6px;
+    padding: 3px 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.filelist-item:hover { background: #eaeef2; }
+.filelist-item.active { background: #ddf4ff; color: #0969da; font-weight: 600; }
+
+.viewer { flex: 1 1 auto; display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.viewer-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-bottom: 1px solid #d0d7de;
+}
+.viewer-name {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    color: #57606a;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.viewer-actions { margin-left: auto; display: flex; gap: 6px; }
+.viewer-body {
+    flex: 1 1 auto;
+    margin: 0;
+    padding: 10px;
+    overflow: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre;
+    min-height: 0;
+}
+
+/* the hidden attribute must win over the display below, or the
+   overlay shows on page load */
+.dropoverlay[hidden] { display: none; }
+
+.dropoverlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(31, 136, 61, .12);
+    border: 3px dashed #1f883d;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    font-weight: 600;
+    color: #1a7f37;
+    z-index: 10;
+    pointer-events: none;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -26,18 +26,62 @@
       'hfsm': 'src/common',
       'templates': 'src/plugins/SoftwareGenerator/templates',
     },
+    // The default is 7s, which the generator can exceed on a slow
+    // link or a single-threaded static server: it pulls every
+    // template through the text! plugin (one request each) alongside
+    // the editor library. Exceeding it aborts the whole load even
+    // though the files arrive fine moments later. Generous but still
+    // bounded, so a genuinely missing module still reports.
+    waitSeconds: 60,
   });
+
+  var CM_ID = 'vendor/codemirror/lib/codemirror';
+  var CM_MODES = [
+    'vendor/codemirror/mode/javascript/javascript', // JSON
+    'vendor/codemirror/mode/clike/clike',           // C++
+    'vendor/codemirror/mode/xml/xml',               // SCXML
+    'vendor/codemirror/mode/shell/shell',           // Makefile (close enough)
+  ];
 
   var el = function (id) { return document.getElementById(id); };
   var mods = null;
   var artifacts = Object.create(null);
   var currentName = null;
+  var CodeMirror = null;   // null until the editor library loads
+  var modelEditor = null;  // the editable model view
+  var viewerEditor = null; // the read-only output view
 
   var EXAMPLES = [
     { label: 'Basic (two states, one event)', file: 'examples/basic.json' },
     { label: 'Features (hierarchy, history, choices)', file: 'examples/features.json' },
     { label: 'Payloads (typed event data)', file: 'examples/payloads.json' },
   ];
+
+  // the textarea remains the fallback when CodeMirror is unavailable,
+  // so every read/write of the model goes through these two
+  function getModelText() {
+    return modelEditor ? modelEditor.getValue() : el('modelInput').value;
+  }
+
+  function setModelText(text) {
+    if (modelEditor) {
+      modelEditor.setValue(text);
+    } else {
+      el('modelInput').value = text;
+    }
+  }
+
+  /** CodeMirror mode for a generated file, by extension. */
+  function modeFor(name) {
+    var ext = extensionOf(name);
+    if (ext === 'hpp' || ext === 'cpp' || ext === 'h' || ext === 'cc') {
+      return 'text/x-c++src';
+    }
+    if (ext === 'json') return 'application/json';
+    if (ext === 'scxml' || ext === 'xml') return 'application/xml';
+    if (name === 'Makefile' || name.indexOf('Makefile.') === 0) return 'text/x-sh';
+    return null; // .mmd / .puml and anything else: plain text
+  }
 
   function setStatus(text, kind) {
     var s = el('status');
@@ -108,13 +152,85 @@
   function showFile(name) {
     currentName = name;
     el('viewerName').textContent = name;
-    el('viewer').textContent = artifacts[name];
+    if (viewerEditor) {
+      viewerEditor.setOption('mode', modeFor(name));
+      viewerEditor.setValue(artifacts[name]);
+      viewerEditor.refresh();
+    } else {
+      el('viewer').textContent = artifacts[name];
+    }
     el('copyBtn').disabled = false;
     el('downloadBtn').disabled = false;
     Array.prototype.forEach.call(
       document.querySelectorAll('.filelist-item'), function (b) {
         b.classList.toggle('active', b.textContent === name);
       });
+  }
+
+  /**
+   * Copy to the clipboard.
+   *
+   * navigator.clipboard only exists in secure contexts -- https, or
+   * localhost. Serving the playground over plain http on a LAN (a
+   * perfectly normal way to host it) leaves it undefined, so calling
+   * it unconditionally would throw inside the click handler. Fall
+   * back to a selection + execCommand, and if even that is
+   * unavailable, select the text so the user can copy it themselves.
+   */
+  function copyText(text, label) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        setStatus('copied ' + label, 'ok');
+      }, function () {
+        legacyCopy(text, label);
+      });
+      return;
+    }
+    legacyCopy(text, label);
+  }
+
+  function legacyCopy(text, label) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    // keep it out of view and out of the tab order
+    ta.setAttribute('readonly', '');
+    ta.setAttribute('aria-hidden', 'true');
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    var ok = false;
+    try {
+      ta.select();
+      ok = document.execCommand && document.execCommand('copy');
+    } catch (e) {
+      ok = false;
+    }
+    document.body.removeChild(ta);
+    if (ok) {
+      setStatus('copied ' + label, 'ok');
+    } else {
+      // last resort: put the text under the user's cursor
+      selectViewerText();
+      setStatus('copy unavailable here — text selected, press ' +
+                (navigator.platform.indexOf('Mac') > -1 ? '\u2318C' : 'Ctrl+C'),
+                'warn');
+    }
+  }
+
+  function selectViewerText() {
+    if (viewerEditor) {
+      viewerEditor.focus();
+      viewerEditor.execCommand('selectAll');
+      return;
+    }
+    var node = el('viewer');
+    if (!node || !window.getSelection || !document.createRange) return;
+    var range = document.createRange();
+    range.selectNodeContents(node);
+    var sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
   }
 
   function downloadOne(name, content) {
@@ -138,13 +254,13 @@
     artifacts = Object.create(null);
     currentName = null;
     el('fileList').textContent = '';
-    el('viewer').textContent = '';
+    if (viewerEditor) { viewerEditor.setValue(''); } else { el('viewer').textContent = ''; }
     el('viewerName').textContent = 'No file selected';
     el('copyBtn').disabled = true;
     el('downloadBtn').disabled = true;
     el('downloadAllBtn').disabled = true;
 
-    var raw = el('modelInput').value;
+    var raw = getModelText();
     if (!raw.trim()) {
       showDiagnostics(['Nothing to generate: paste or load a model first.'], 'error');
       setStatus('no model', 'error');
@@ -243,7 +359,7 @@
         if (!r.ok) throw new Error(r.status + ' ' + r.statusText);
         return r.text();
       }).then(function (text) {
-        el('modelInput').value = text;
+        setModelText(text);
         setStatus('example loaded');
         generate();
       }).catch(function (e) {
@@ -256,7 +372,7 @@
   function readFile(file) {
     var reader = new FileReader();
     reader.onload = function () {
-      el('modelInput').value = String(reader.result);
+      setModelText(String(reader.result));
       setStatus('loaded ' + file.name);
       generate();
     };
@@ -298,11 +414,7 @@
     });
     el('copyBtn').addEventListener('click', function () {
       if (!currentName) return;
-      navigator.clipboard.writeText(artifacts[currentName]).then(function () {
-        setStatus('copied ' + currentName, 'ok');
-      }, function () {
-        setStatus('clipboard unavailable', 'warn');
-      });
+      copyText(artifacts[currentName], currentName);
     });
     el('downloadBtn').addEventListener('click', function () {
       if (currentName) downloadOne(currentName, artifacts[currentName]);
@@ -318,8 +430,51 @@
     wireDragAndDrop();
   }
 
+  /**
+   * Upgrade the plain textarea / pre into highlighted CodeMirror
+   * views. Entirely optional: if the library fails to load the app
+   * keeps working with the plain controls, so highlighting can never
+   * be the reason generation breaks.
+   */
+  function initEditors(cm) {
+    CodeMirror = cm;
+    modelEditor = CodeMirror.fromTextArea(el('modelInput'), {
+      mode: 'application/json',
+      lineNumbers: true,
+      lineWrapping: false,
+      matchBrackets: true,
+      tabSize: 2,
+      viewportMargin: 30,
+    });
+    modelEditor.setSize('100%', '100%');
+
+    viewerEditor = CodeMirror(el('viewer'), {
+      value: '',
+      mode: null,
+      lineNumbers: true,
+      lineWrapping: false,
+      readOnly: true,     // still selectable / copyable
+      viewportMargin: 30,
+    });
+    viewerEditor.setSize('100%', '100%');
+
+    // re-render what is already on screen
+    if (currentName) showFile(currentName);
+  }
+
   setStatus('loading generator…');
   wire();
+
+  requirejs([CM_ID].concat(CM_MODES), function (cm) {
+    try {
+      initEditors(cm);
+    } catch (e) {
+      // never let the editor take the app down with it
+      console.warn('CodeMirror init failed, using plain views:', e);
+    }
+  }, function (err) {
+    console.warn('CodeMirror unavailable, using plain views:', err.message);
+  });
 
   requirejs([
     'hfsm/resolveModel',

--- a/web/app.js
+++ b/web/app.js
@@ -276,7 +276,12 @@
       return;
     }
 
-    var namespace = (el('namespaceInput').value || 'state_machine').trim();
+    // Same precedence as the CLI (bin/hfsm-gen.js): an explicit
+    // value wins, then the model's own `namespace`, then the default.
+    // Leaving the box empty therefore means "use the model's".
+    var namespace = (el('namespaceInput').value || '').trim() ||
+        (typeof model.namespace === 'string' && model.namespace.trim()) ||
+        'state_machine';
     if (!/^[A-Za-z_]\w*(::[A-Za-z_]\w*)*$/.test(namespace)) {
       showDiagnostics(['Invalid C++ namespace "' + namespace +
                        '" (expected identifier or identifier::identifier...).'], 'error');
@@ -302,6 +307,10 @@
       setStatus('model rejected', 'error');
       return;
     }
+
+    // reflect the namespace actually used, so an empty box is never
+    // ambiguous about what it resolved to
+    el('namespaceInput').placeholder = namespace;
 
     try {
       var out = mods.MetaTemplates.renderHFSM(model, namespace);

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,345 @@
+/**
+ * HFSM Playground -- a fully static front end for the model checker,
+ * code generator and interop exporters.
+ *
+ * It loads the SAME AMD modules the CLI and the WebGME plugin use
+ * (src/common/* and the SoftwareGenerator templates), so there is no
+ * second implementation to keep in sync. Everything runs in the
+ * browser: no server, no database, no authentication.
+ *
+ * Note: the template loader uses XHR, so the page must be served over
+ * http(s) -- opening index.html from the filesystem will not work.
+ * `npm run web` (or any static file server) is enough.
+ */
+/* global requirejs */
+(function () {
+  'use strict';
+
+  requirejs.config({
+    baseUrl: '.',
+    paths: {
+      // the generator modules reference these ids exactly as they do
+      // inside WebGME, so the sources need no modification here
+      'bower/handlebars/handlebars.min': 'vendor/handlebars.min',
+      'underscore': 'vendor/underscore-umd',
+      'text': 'vendor/text',
+      'hfsm': 'src/common',
+      'templates': 'src/plugins/SoftwareGenerator/templates',
+    },
+  });
+
+  var el = function (id) { return document.getElementById(id); };
+  var mods = null;
+  var artifacts = Object.create(null);
+  var currentName = null;
+
+  var EXAMPLES = [
+    { label: 'Basic (two states, one event)', file: 'examples/basic.json' },
+    { label: 'Features (hierarchy, history, choices)', file: 'examples/features.json' },
+    { label: 'Payloads (typed event data)', file: 'examples/payloads.json' },
+  ];
+
+  function setStatus(text, kind) {
+    var s = el('status');
+    s.textContent = text || '';
+    s.className = 'status' + (kind ? ' status-' + kind : '');
+  }
+
+  function showDiagnostics(items, kind) {
+    var box = el('diagnostics');
+    if (!items || !items.length) {
+      box.hidden = true;
+      box.textContent = '';
+      return;
+    }
+    box.hidden = false;
+    box.className = 'diagnostics diagnostics-' + kind;
+    box.textContent = '';
+    items.forEach(function (item) {
+      var line = document.createElement('div');
+      line.className = 'diag-line';
+      line.textContent = item;
+      box.appendChild(line);
+    });
+  }
+
+  function extensionOf(name) {
+    var i = name.lastIndexOf('.');
+    return i > -1 ? name.slice(i + 1) : '';
+  }
+
+  // group related outputs so the list is readable at a glance
+  function groupOf(name) {
+    var ext = extensionOf(name);
+    if (ext === 'mmd' || ext === 'puml' || ext === 'scxml') return 'Diagrams / interop';
+    if (name === 'Makefile' || name.indexOf('Makefile.') === 0 ||
+        name.indexOf('_test.cpp') > -1) return 'Test bench';
+    return 'Generated C++';
+  }
+
+  function renderFileList() {
+    var list = el('fileList');
+    list.textContent = '';
+    var names = Object.keys(artifacts).sort();
+    var groups = Object.create(null);
+    names.forEach(function (n) {
+      var g = groupOf(n);
+      (groups[g] = groups[g] || []).push(n);
+    });
+    ['Generated C++', 'Test bench', 'Diagrams / interop'].forEach(function (g) {
+      if (!groups[g]) return;
+      var head = document.createElement('li');
+      head.className = 'filelist-group';
+      head.textContent = g;
+      list.appendChild(head);
+      groups[g].forEach(function (n) {
+        var item = document.createElement('li');
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'filelist-item';
+        btn.textContent = n;
+        btn.addEventListener('click', function () { showFile(n); });
+        item.appendChild(btn);
+        list.appendChild(item);
+      });
+    });
+  }
+
+  function showFile(name) {
+    currentName = name;
+    el('viewerName').textContent = name;
+    el('viewer').textContent = artifacts[name];
+    el('copyBtn').disabled = false;
+    el('downloadBtn').disabled = false;
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.filelist-item'), function (b) {
+        b.classList.toggle('active', b.textContent === name);
+      });
+  }
+
+  function downloadOne(name, content) {
+    var blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    // revoke on the next tick so the click has certainly started
+    setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+  }
+
+  function generate() {
+    if (!mods) {
+      setStatus('still loading the generator…', 'warn');
+      return;
+    }
+    artifacts = Object.create(null);
+    currentName = null;
+    el('fileList').textContent = '';
+    el('viewer').textContent = '';
+    el('viewerName').textContent = 'No file selected';
+    el('copyBtn').disabled = true;
+    el('downloadBtn').disabled = true;
+    el('downloadAllBtn').disabled = true;
+
+    var raw = el('modelInput').value;
+    if (!raw.trim()) {
+      showDiagnostics(['Nothing to generate: paste or load a model first.'], 'error');
+      setStatus('no model', 'error');
+      return;
+    }
+
+    var model;
+    try {
+      model = JSON.parse(raw);
+    } catch (e) {
+      showDiagnostics(['Invalid JSON: ' + e.message], 'error');
+      setStatus('parse error', 'error');
+      return;
+    }
+
+    var namespace = (el('namespaceInput').value || 'state_machine').trim();
+    if (!/^[A-Za-z_]\w*(::[A-Za-z_]\w*)*$/.test(namespace)) {
+      showDiagnostics(['Invalid C++ namespace "' + namespace +
+                       '" (expected identifier or identifier::identifier...).'], 'error');
+      setStatus('bad namespace', 'error');
+      return;
+    }
+    var badSegments = namespace.split('::').filter(function (seg) {
+      return mods.checkModel.cppKeywords.indexOf(seg) > -1;
+    });
+    if (badSegments.length) {
+      showDiagnostics(['Invalid C++ namespace: segment(s) ' +
+                       badSegments.join(', ') + ' are C++ keywords.'], 'error');
+      setStatus('bad namespace', 'error');
+      return;
+    }
+
+    try {
+      mods.resolveModel.resolve(model);
+      mods.processor.processModel(model); // throws strings on violations
+    } catch (err) {
+      showDiagnostics([typeof err === 'string' ? err : (err && err.message) || String(err)],
+                      'error');
+      setStatus('model rejected', 'error');
+      return;
+    }
+
+    try {
+      var out = mods.MetaTemplates.renderHFSM(model, namespace);
+      Object.keys(out).forEach(function (k) { artifacts[k] = out[k]; });
+      if (el('testBenchInput').checked) {
+        var tb = mods.MetaTemplates.renderTestCode(model, namespace);
+        Object.keys(tb).forEach(function (k) { artifacts[k] = tb[k]; });
+      }
+      Object.keys(model.objects).sort().forEach(function (p) {
+        var obj = model.objects[p];
+        if (obj.type === 'State Machine' || obj.type === 'Library') {
+          artifacts[obj.sanitizedName + '.mmd'] = mods.exporters.toMermaid(model, p);
+          artifacts[obj.sanitizedName + '.puml'] = mods.exporters.toPlantUML(model, p);
+          artifacts[obj.sanitizedName + '.scxml'] = mods.exporters.toSCXML(model, p);
+        }
+      });
+    } catch (err) {
+      showDiagnostics(['Generation failed: ' +
+                       (typeof err === 'string' ? err : (err && err.message) || String(err))],
+                      'error');
+      setStatus('generation failed', 'error');
+      return;
+    }
+
+    // non-fatal model warnings surface the same way the CLI prints them
+    showDiagnostics(model.warnings || [], 'warn');
+
+    var count = Object.keys(artifacts).length;
+    renderFileList();
+    el('downloadAllBtn').disabled = count === 0;
+    setStatus(count + ' file' + (count === 1 ? '' : 's') +
+              ((model.warnings && model.warnings.length) ?
+               ' · ' + model.warnings.length + ' warning' +
+               (model.warnings.length === 1 ? '' : 's') : ''),
+              (model.warnings && model.warnings.length) ? 'warn' : 'ok');
+    var first = Object.keys(artifacts).sort().filter(function (n) {
+      return extensionOf(n) === 'hpp';
+    })[0] || Object.keys(artifacts).sort()[0];
+    if (first) showFile(first);
+  }
+
+  function loadExampleList() {
+    var sel = el('exampleSelect');
+    EXAMPLES.forEach(function (ex) {
+      var opt = document.createElement('option');
+      opt.value = ex.file;
+      opt.textContent = ex.label;
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', function () {
+      var file = sel.value;
+      if (!file) return;
+      setStatus('loading example…');
+      fetch(file).then(function (r) {
+        if (!r.ok) throw new Error(r.status + ' ' + r.statusText);
+        return r.text();
+      }).then(function (text) {
+        el('modelInput').value = text;
+        setStatus('example loaded');
+        generate();
+      }).catch(function (e) {
+        showDiagnostics(['Could not load ' + file + ': ' + e.message], 'error');
+        setStatus('load failed', 'error');
+      });
+    });
+  }
+
+  function readFile(file) {
+    var reader = new FileReader();
+    reader.onload = function () {
+      el('modelInput').value = String(reader.result);
+      setStatus('loaded ' + file.name);
+      generate();
+    };
+    reader.onerror = function () {
+      showDiagnostics(['Could not read ' + file.name], 'error');
+    };
+    reader.readAsText(file);
+  }
+
+  function wireDragAndDrop() {
+    var overlay = el('dropOverlay');
+    var depth = 0;
+    window.addEventListener('dragenter', function (e) {
+      e.preventDefault();
+      depth++;
+      overlay.hidden = false;
+    });
+    window.addEventListener('dragover', function (e) { e.preventDefault(); });
+    window.addEventListener('dragleave', function (e) {
+      e.preventDefault();
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) overlay.hidden = true;
+    });
+    window.addEventListener('drop', function (e) {
+      e.preventDefault();
+      depth = 0;
+      overlay.hidden = true;
+      var f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+      if (f) readFile(f);
+    });
+  }
+
+  function wire() {
+    el('generateBtn').addEventListener('click', generate);
+    el('fileInput').addEventListener('change', function (e) {
+      var f = e.target.files && e.target.files[0];
+      if (f) readFile(f);
+      e.target.value = ''; // allow re-picking the same file
+    });
+    el('copyBtn').addEventListener('click', function () {
+      if (!currentName) return;
+      navigator.clipboard.writeText(artifacts[currentName]).then(function () {
+        setStatus('copied ' + currentName, 'ok');
+      }, function () {
+        setStatus('clipboard unavailable', 'warn');
+      });
+    });
+    el('downloadBtn').addEventListener('click', function () {
+      if (currentName) downloadOne(currentName, artifacts[currentName]);
+    });
+    el('downloadAllBtn').addEventListener('click', function () {
+      // one download per file: no archiving library needed, so the
+      // page stays dependency-free and works offline
+      Object.keys(artifacts).sort().forEach(function (n, i) {
+        setTimeout(function () { downloadOne(n, artifacts[n]); }, i * 120);
+      });
+    });
+    loadExampleList();
+    wireDragAndDrop();
+  }
+
+  setStatus('loading generator…');
+  wire();
+
+  requirejs([
+    'hfsm/resolveModel',
+    'hfsm/processor',
+    'hfsm/checkModel',
+    'hfsm/exporters',
+    'templates/MetaTemplates',
+  ], function (resolveModel, processor, checkModel, exporters, MetaTemplates) {
+    mods = {
+      resolveModel: resolveModel,
+      processor: processor,
+      checkModel: checkModel,
+      exporters: exporters,
+      MetaTemplates: MetaTemplates,
+    };
+    setStatus('ready');
+  }, function (err) {
+    showDiagnostics(['Failed to load the generator modules: ' + err.message,
+                     'If you opened this file directly, serve it over http instead ' +
+                     '(the template loader uses XHR).'], 'error');
+    setStatus('load failed', 'error');
+  });
+}());

--- a/web/index.html
+++ b/web/index.html
@@ -35,7 +35,7 @@
     </div>
     <div class="pane-foot">
       <label class="opt">Namespace
-        <input type="text" id="namespaceInput" value="state_machine" spellcheck="false"/>
+        <input type="text" id="namespaceInput" value="" spellcheck="false" placeholder="state_machine" title="Overrides the namespace. Leave empty to use the model's own `namespace`, or state_machine if it declares none."/>
       </label>
       <label class="opt checkbox">
         <input type="checkbox" id="testBenchInput" checked/> test bench

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>HFSM Playground</title>
+<link rel="stylesheet" href="app.css"/>
+</head>
+<body>
+<header class="topbar">
+  <span class="brand">HFSM Playground</span>
+  <span class="tagline">model in, C++ and diagrams out &mdash; entirely in your browser</span>
+  <a class="repo" href="https://github.com/finger563/webgme-hfsm" target="_blank" rel="noopener">webgme-hfsm</a>
+</header>
+
+<main class="layout">
+  <section class="pane pane-input">
+    <div class="pane-head">
+      <h2>Model</h2>
+      <div class="controls">
+        <select id="exampleSelect" aria-label="Load an example model">
+          <option value="">Load example&hellip;</option>
+        </select>
+        <label class="filebtn">
+          Open file&hellip;
+          <input type="file" id="fileInput" accept=".json,application/json"/>
+        </label>
+      </div>
+    </div>
+    <textarea id="modelInput" spellcheck="false"
+              aria-label="Model JSON"
+              placeholder="Paste a model JSON here, load an example, open a file, or drop a .json file anywhere on the page."></textarea>
+    <div class="pane-foot">
+      <label class="opt">Namespace
+        <input type="text" id="namespaceInput" value="state_machine" spellcheck="false"/>
+      </label>
+      <label class="opt checkbox">
+        <input type="checkbox" id="testBenchInput" checked/> test bench
+      </label>
+      <button id="generateBtn" class="primary" type="button">Generate</button>
+    </div>
+  </section>
+
+  <section class="pane pane-output">
+    <div class="pane-head">
+      <h2>Output</h2>
+      <div class="controls">
+        <span id="status" class="status" role="status" aria-live="polite"></span>
+        <button id="downloadAllBtn" type="button" disabled>Download all</button>
+      </div>
+    </div>
+    <div id="diagnostics" class="diagnostics" hidden></div>
+    <div class="results">
+      <ul id="fileList" class="filelist" aria-label="Generated files"></ul>
+      <div class="viewer">
+        <div class="viewer-head">
+          <span id="viewerName" class="viewer-name">No file selected</span>
+          <span class="viewer-actions">
+            <button id="copyBtn" type="button" disabled>Copy</button>
+            <button id="downloadBtn" type="button" disabled>Download</button>
+          </span>
+        </div>
+        <pre id="viewer" class="viewer-body" tabindex="0"></pre>
+      </div>
+    </div>
+  </section>
+</main>
+
+<div id="dropOverlay" class="dropoverlay" hidden>Drop a model .json</div>
+
+<script src="vendor/require.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>HFSM Playground</title>
+<link rel="stylesheet" href="vendor/codemirror/lib/codemirror.css"/>
 <link rel="stylesheet" href="app.css"/>
 </head>
 <body>
@@ -27,9 +28,11 @@
         </label>
       </div>
     </div>
-    <textarea id="modelInput" spellcheck="false"
-              aria-label="Model JSON"
-              placeholder="Paste a model JSON here, load an example, open a file, or drop a .json file anywhere on the page."></textarea>
+    <div class="editor-wrap">
+      <textarea id="modelInput" spellcheck="false"
+                aria-label="Model JSON"
+                placeholder="Paste a model JSON here, load an example, open a file, or drop a .json file anywhere on the page."></textarea>
+    </div>
     <div class="pane-foot">
       <label class="opt">Namespace
         <input type="text" id="namespaceInput" value="state_machine" spellcheck="false"/>
@@ -60,7 +63,7 @@
             <button id="downloadBtn" type="button" disabled>Download</button>
           </span>
         </div>
-        <pre id="viewer" class="viewer-body" tabindex="0"></pre>
+        <div id="viewer" class="viewer-body" tabindex="0"></div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Next roadmap step toward *"host this locally and as a webapp easily, without WebGME auth / collaboration"*: a single-page app that runs the model checker, the C++ generator and the interop exporters **entirely in the browser**. No server, no database, no authentication, no CDN — and it works offline.

Load a model (bundled example, file picker, drag-and-drop anywhere on the page, or paste), validate it, generate the full C++ HFSM plus optional test bench and Mermaid / PlantUML / SCXML, then view / copy / download the results. Model errors stop generation and are shown verbatim; non-fatal warnings surface the way the CLI prints them.

```bash
npm run web        # build + serve on http://localhost:8080
```

Also published to GitHub Pages automatically (`.github/workflows/pages.yml`) on pushes that touch the generator, templates, fixtures, or the page.

## The property that makes this safe

The playground **reimplements nothing**. `scripts/build-web.sh` copies `src/common/*` and the SoftwareGenerator templates into the build verbatim, and the page loads them under the same AMD module ids WebGME uses — so the browser runs the identical `resolveModel → checkModel → processor → templates` pipeline as `hfsm-gen`.

`scripts/verify-web-build.js` enforces it in CI:
1. every expected file is present in the build,
2. the copied `src/common` modules are byte-identical to the sources,
3. `index.html` loads no remote assets (guards the offline/self-contained property — verified in both directions, including a negative test with an injected CDN tag),
4. loading the generator **out of the build output** and regenerating every bundled example reproduces the committed goldens byte for byte.

The bundled examples *are* the test fixtures, so the playground can only demo models CI already covers.

## Not included (and why)

- **Editing and simulation** — built on WebGME's client APIs (territories, transactions, GME nodes); bringing them across means decoupling the simulator first, which is the Rust/WASM track.
- **Persistence and collaboration** — need a server by nature. That's the trade for needing no infrastructure.

## Test plan

- [x] `verify-web-build.js`: 3 models, **36 files identical to the goldens**, loaded from the build output
- [x] Verified in a real browser: loaded the `features` example, generated 12 files client-side, hashed each in-page with SHA-256 and compared to the committed goldens — **12/12 byte-identical**
- [x] Payloads example generates correct typed structs (doc comments, defaults, `event_data_to_string`) in-browser
- [x] Negative test on the CDN guard (injected a remote `<script src>` → build correctly rejected)
- [x] Existing suites unaffected: 75 tests, generated-code compile + trace checks green
- [x] Found and fixed one real bug while testing: the drop overlay's `display: flex` was overriding the `hidden` attribute, so it showed on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)