### PR TITLE
Phase B: the visualizer no longer depends on WebGME

### DIFF
--- a/src/common/viz/HostServices.js
+++ b/src/common/viz/HostServices.js
@@ -1,0 +1,82 @@
+/**
+ * The UI services the visualizer needs from whatever application is
+ * hosting it -- the counterpart to ModelBackend.
+ *
+ * ModelBackend abstracts the MODEL: what the nodes are and how they
+ * change. This abstracts the HOST: how to pop a context menu, how to
+ * edit a block of documentation, and where dragged items come from.
+ * Those are the last things in the widget that only WebGME could
+ * provide, and they are the reason it could not be loaded anywhere
+ * else -- a top-level dependency on `js/Controls/ContextMenu` fails
+ * to resolve long before any of it runs.
+ *
+ * CONTEXT MENU
+ * ------------
+ * `contextMenu(items, onSelect, position)` where `items` is
+ *
+ *   { '<key>': { name: 'Move Here', icon: false }, ... }
+ *
+ * and `onSelect(key)` fires for the chosen entry. Insertion order is
+ * the display order.
+ *
+ * DOCUMENTATION
+ * -------------
+ * `editDocument(text, onSave)` opens whatever rich-text editing the
+ * host offers and calls `onSave(newText)` if the user commits. A host
+ * with nothing better can fall back to a plain textarea; the widget
+ * only cares that it gets the new text.
+ *
+ * DRAG AND DROP
+ * -------------
+ * `makeDroppable(element, handlers)` registers `element` as a drop
+ * target for the host's palette, and returns a function that undoes
+ * it (or undefined when the host has no palette to drag from -- the
+ * playground draws its own).
+ *
+ * `handlers` are called with a NORMALIZED descriptor
+ *
+ *   { items: ['<node id>', ...], effects: ['<effect>', ...] }
+ *
+ * so the widget never sees the host's own drag payload format. The
+ * ids are the host's model ids, which is what makes them meaningful
+ * to the ModelBackend the widget is paired with.
+ */
+define([], function () {
+  'use strict';
+
+  var REQUIRED = ['contextMenu', 'editDocument', 'makeDroppable'];
+
+  return {
+    REQUIRED: REQUIRED,
+
+    /**
+     * Throw unless `services` implements the whole contract, so a
+     * partial host fails at wiring time rather than the first time
+     * someone right-clicks.
+     */
+    assertImplements: function (services, label) {
+      var missing = REQUIRED.filter(function (m) {
+        return typeof services[m] !== 'function';
+      });
+      if (missing.length) {
+        throw new Error((label || 'HostServices') +
+                        ' is missing: ' + missing.join(', '));
+      }
+      return services;
+    },
+
+    /**
+     * A host that offers none of this: menus and documentation
+     * editing simply do not happen, and nothing can be dragged in.
+     * Useful for a read-only view, and it keeps every call site free
+     * of null checks.
+     */
+    none: function () {
+      return {
+        contextMenu: function () {},
+        editDocument: function () {},
+        makeDroppable: function () { return undefined; },
+      };
+    },
+  };
+});

--- a/src/visualizers/panels/HFSMViz/HFSMVizPanel.js
+++ b/src/visualizers/panels/HFSMViz/HFSMVizPanel.js
@@ -8,12 +8,16 @@ define([
     'js/PanelBase/PanelBaseWithHeader',
     'js/PanelManager/IActivePanel',
     'widgets/HFSMViz/HFSMVizWidget',
+    'widgets/HFSMViz/WebGMEBackend',
+    'widgets/HFSMViz/WebGMEHost',
     './HFSMVizControl',
     'underscore'
 ], function (
     PanelBaseWithHeader,
     IActivePanel,
     HFSMVizWidget,
+    WebGMEBackend,
+    WebGMEHost,
     HFSMVizControl,
     _
 ) {
@@ -48,7 +52,17 @@ define([
         //set Widget title
         this.setTitle('');
 
-        this.widget = new HFSMVizWidget(this.logger, this.$el, this._client);
+        // The panel is where WebGME meets the widget: the widget
+        // itself depends on neither the client nor the WebGME UI, so
+        // its two adapters are wired up here.
+        var client = this._client;
+        this.widget = new HFSMVizWidget(
+            this.logger, this.$el, client,
+            function (getNodes) {
+                return WebGMEBackend(client, getNodes, WebGMEGlobal);
+            },
+            WebGMEHost(client, WebGMEGlobal)
+        );
 
         this.widget.setTitle = function (title) {
             self.setTitle(title);

--- a/src/visualizers/widgets/HFSMViz/Dialog/Dialog.js
+++ b/src/visualizers/widgets/HFSMViz/Dialog/Dialog.js
@@ -2,13 +2,11 @@
  * @author William Emfinger  https://github.com/finger563
  */
 
-define(['js/util',
-        'bower/mustache.js/mustache.min',
+define(['bower/mustache.js/mustache.min',
         'text!./Dialog.html',
         'text!./Type.html',
         'css!./Dialog.css'],
-       function(Util,
-                mustache,
+       function(mustache,
                 DialogTemplate,
                 TypeTemplate){
            'use strict';

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -112,7 +112,10 @@ define([
                         '(see src/common/viz/ModelBackend.js)');
       }
       this._backend = backendFactory(getNodes);
-      this._host = hostServices || HostServices.none();
+      // fail at wiring time, not at the first right-click
+      this._host = hostServices
+        ? HostServices.assertImplements(hostServices, 'host services')
+        : HostServices.none();
       this._initialize();
 
       this._logger.debug("ctor finished");
@@ -2298,6 +2301,13 @@ define([
 
     HFSMVizWidget.prototype.destroy = function () {
       this._detachClientEventListeners();
+      // the host registered handlers on our element; leaving them
+      // attached would keep this widget alive and double up if
+      // another is built over the same DOM
+      if (this._undoDroppable) {
+        this._undoDroppable();
+        this._undoDroppable = null;
+      }
       this.clearNodes();
       this.shutdown();
     };

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -1,4 +1,4 @@
-/*globals define, WebGMEGlobal*/
+/*globals define*/
 /*jshint browser: true*/
 
 /**
@@ -9,15 +9,10 @@ define([
   // local
   "text!./HFSM.html",
   "./Dialog/Dialog",
-  "./WebGMEBackend",
+  "hfsm/viz/HostServices",
   "./Simulator/Simulator",
   "./Simulator/Choice",
   // built-ins
-  "js/Constants",
-  "js/Controls/ContextMenu",
-  "js/DragDrop/DropTarget",
-  "js/DragDrop/DragConstants",
-  "decorators/DocumentDecorator/DiagramDesigner/DocumentEditorDialog",
   // cytoscape
   "bower/cytoscape/dist/cytoscape.min",
   "cytoscape-edgehandles",
@@ -39,15 +34,10 @@ define([
     // local
     HFSMHtml,
     Dialog,
-    WebGMEBackend,
+    HostServices,
     Simulator,
     Choice,
     // built-ins
-    CONSTANTS,
-    ContextMenu,
-    dropTarget,
-    DROP_CONSTANTS,
-    DocumentEditorDialog,
     // cytoscape
     cytoscape,
     cyEdgehandles,
@@ -90,17 +80,26 @@ define([
     };
 
     /**
-     * @param backendFactory  optional; getNodes -> ModelBackend. The
-     *   backend is the ONLY thing here that knows about WebGME, so a
-     *   host with a different store (the playground's LocalBackend
-     *   over plain JSON) installs it here rather than editing this
-     *   file. It takes the node-table getter because the descriptor
-     *   table lives on the widget and reads are served from it.
+     * This widget knows nothing about WebGME. Both of the things that
+     * would tie it to one application are handed in:
      *
-     *   Defaults to WebGMEBackend, which is this widget's WebGME
-     *   host wiring, not a hard dependency of the widget itself.
+     * @param backendFactory  getNodes -> ModelBackend, the model. It
+     *   takes the node-table getter because the descriptor table
+     *   lives on the widget and reads are served from it.
+     * @param hostServices    HostServices, the surrounding
+     *   application: context menus, the documentation editor, the
+     *   palette dragged from.
+     *
+     * The WebGME panel wires up WebGMEBackend and WebGMEHost; the
+     * playground wires up its own. Defaulting to the WebGME ones here
+     * would put them back in this module's dependency list, which is
+     * exactly what stops it loading anywhere else.
+     *
+     * @param client  passed through to the control for WebGME; unused
+     *   by the widget itself.
      */
-    HFSMVizWidget = function (logger, container, client, backendFactory) {
+    HFSMVizWidget = function (logger, container, client, backendFactory,
+                              hostServices) {
       this._logger = logger.fork("Widget");
 
       this._el = container;
@@ -108,9 +107,12 @@ define([
       this._client = client;
       var self = this;
       var getNodes = function () { return self.nodes; };
-      this._backend = backendFactory
-        ? backendFactory(getNodes)
-        : WebGMEBackend(client, getNodes, WebGMEGlobal);
+      if (typeof backendFactory !== 'function') {
+        throw new Error('HFSMVizWidget needs a backend factory ' +
+                        '(see src/common/viz/ModelBackend.js)');
+      }
+      this._backend = backendFactory(getNodes);
+      this._host = hostServices || HostServices.none();
       this._initialize();
 
       this._logger.debug("ctor finished");
@@ -933,9 +935,8 @@ define([
     HFSMVizWidget.prototype.onEditDocumentation = function(gmeId) {
       var self = this;
       var documentation = self.nodes[gmeId].documentation;
-      var editorDialog = new DocumentEditorDialog();
 
-      editorDialog.initialize(documentation, function (text) {
+      self._host.editDocument(documentation, function (text) {
         try {
           self._backend.transact("updated documentation for " + gmeId, function () {
             self._backend.setAttribute(gmeId, "documentation", text);
@@ -945,8 +946,6 @@ define([
           console.error(e);
         }
       });
-
-      editorDialog.show();
     };
 
     HFSMVizWidget.prototype.onPanningClicked = function() {
@@ -1558,19 +1557,8 @@ define([
 
     /* * * * * * * * Context Menu Functions    * * * * * * * */
 
-    HFSMVizWidget.prototype.createWebGMEContextMenu = function(menuItems, fnCallback, position) {
-      var self = this;
-
-      var menu = new ContextMenu({
-        items: menuItems,
-        callback: function(key) {
-          if (fnCallback)
-            fnCallback(key);
-        }
-      });
-
-      position = position || {x: 200, y:200};
-      menu.show(position);
+    HFSMVizWidget.prototype.createContextMenu = function(menuItems, fnCallback, position) {
+      this._host.contextMenu(menuItems, fnCallback, position);
     };
 
     /**
@@ -1716,10 +1704,10 @@ define([
       if (self._readOnly)
         return false;
 
-      var isValid = dragInfo[DROP_CONSTANTS.DRAG_ITEMS].length > 0;
+      var isValid = dragInfo.items.length > 0;
 
-      for (var i=0; i<dragInfo[DROP_CONSTANTS.DRAG_ITEMS].length; i++) {
-        var nodeId = dragInfo[DROP_CONSTANTS.DRAG_ITEMS][i];
+      for (var i=0; i<dragInfo.items.length; i++) {
+        var nodeId = dragInfo.items[i];
         if (!self._canCreateChild( nodeId, parentId )) {
           isValid = false;
           break;
@@ -1922,7 +1910,7 @@ define([
 
     HFSMVizWidget.prototype.dropRequiresMenu = function(dragInfo) {
       // default to all items require a drop menu
-      var requiresMenu = dragInfo && dragInfo[DROP_CONSTANTS.DRAG_EFFECTS].length > 1;
+      var requiresMenu = dragInfo && dragInfo.effects.length > 1;
 
       return requiresMenu;
     };
@@ -1941,7 +1929,7 @@ define([
           self.showDropMenu(menuPos, childPosition, dragInfo);
         else {
           self._createNode(
-            dragInfo[DROP_CONSTANTS.DRAG_ITEMS],
+            dragInfo.items,
             parentId,
             childPosition
           );
@@ -1958,7 +1946,7 @@ define([
               icon: false,
               fn: function() {
                 self._instanceNodes(
-                  dragInfo[DROP_CONSTANTS.DRAG_ITEMS],
+                  dragInfo.items,
                   parentId,
                   childPosition
                 );
@@ -1969,7 +1957,7 @@ define([
               icon: false,
               fn: function() {
                 self._moveNodes(
-                  dragInfo[DROP_CONSTANTS.DRAG_ITEMS],
+                  dragInfo.items,
                   parentId,
                   childPosition
                 );
@@ -1980,7 +1968,7 @@ define([
               icon: false,
               fn: function() {
                 self._copyNodes(
-                  dragInfo[DROP_CONSTANTS.DRAG_ITEMS],
+                  dragInfo.items,
                   parentId,
                   childPosition
                 );
@@ -1991,7 +1979,7 @@ define([
       if (self._readOnly)
         return;
 
-      self.createWebGMEContextMenu(options, function(option) {
+      self.createContextMenu(options, function(option) {
         if (options[option] && options[option].fn)
           options[option].fn();
       }, menuPosition);
@@ -2004,7 +1992,7 @@ define([
       self._right.addClass("drop-area");
       //self._div.append(self.__iconAssignNullPointer);
 
-      dropTarget.makeDroppable(self._right, {
+      self._undoDroppable = self._host.makeDroppable(self._right, {
         over: function (event, dragInfo) {
           self._isDropping = true;
           self._dropInfo = dragInfo;
@@ -2088,7 +2076,7 @@ define([
         targetPos.x += $(self._left).width();
         targetPos = self._relativeToWindowPos( targetPos );
 
-        self.createWebGMEContextMenu(options, function(option) {
+        self.createContextMenu(options, function(option) {
           if (options[option] && options[option].fn)
             options[option].fn();
         }, targetPos);
@@ -2283,27 +2271,29 @@ define([
 
     /* * * * * * * * Visualizer life cycle callbacks * * * * * * * */
 
-    // These two stay on the WebGME client on purpose: branch changes
-    // and the shared active-selection state are properties of the
-    // WebGME *host*, not of the model. A host without branches simply
-    // never calls them, so they are not part of ModelBackend.
+    // Branch changes and the shared active-selection state are
+    // properties of the HOST application, not of the model, so they
+    // are the host's to provide -- and optional, since a host without
+    // branches or a shared selection has nothing to report.
     HFSMVizWidget.prototype._attachClientEventListeners = function () {
+      var self = this;
       this._detachClientEventListeners();
-      WebGMEGlobal.State.on("change:" + CONSTANTS.STATE_ACTIVE_SELECTION,
-                            this._stateActiveSelectionChanged, this);
-      this.boundBranchChanged = this._branchChanged.bind(this);
-      this._client.addEventListener(this._client.CONSTANTS.BRANCH_CHANGED,
-                                    this.boundBranchChanged);
-      this.boundBranchStatusChanged = this._branchStatusChanged.bind(this);
-      this._client.addEventListener(this._client.CONSTANTS.BRANCH_STATUS_CHANGED,
-                                    this.boundBranchStatusChanged);
+      if (!this._host.observe)
+        return;
+      this._stopObserving = this._host.observe({
+        selectionChanged: function (model, selection, opts) {
+          self._stateActiveSelectionChanged(model, selection, opts);
+        },
+        branchChanged: function (args) { self._branchChanged(args); },
+        branchStatusChanged: function (args) { self._branchStatusChanged(args); },
+      });
     }
 
     HFSMVizWidget.prototype._detachClientEventListeners = function () {
-      WebGMEGlobal.State.off("change:" + CONSTANTS.STATE_ACTIVE_SELECTION,
-                             this._stateActiveSelectionChanged, this);
-      this._client.removeEventListener(this._client.CONSTANTS.BRANCH_CHANGED, this.boundBranchChanged);
-      this._client.removeEventListener(this._client.CONSTANTS.BRANCH_STATUS_CHANGED, this.boundBranchStatusChanged);
+      if (this._stopObserving) {
+        this._stopObserving();
+        this._stopObserving = null;
+      }
     }
 
     HFSMVizWidget.prototype.destroy = function () {

--- a/src/visualizers/widgets/HFSMViz/Simulator/Choice.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Choice.js
@@ -2,13 +2,11 @@
  * @author William Emfinger  https://github.com/finger563
  */
 
-define(['js/util',
-	'q',
+define(['q',
 	'bower/mustache.js/mustache.min',
 	'text!./Choice.html',
 	'css!./Choice.css'],
-       function(Util,
-		Q,
+       function(Q,
 		mustache,
 		ChoiceTemplate){
            'use strict';

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
@@ -2,8 +2,7 @@
  * @author William Emfinger  https://github.com/finger563
  */
 
-define(['js/util',
-        'q',
+define(['q',
         './Choice',
         './FormDialog',
         'hfsm/declParser',
@@ -14,8 +13,7 @@ define(['js/util',
         'css!decorators/UMLStateMachineDecorator/DiagramDesigner/UMLStateMachineDecorator.DiagramDesignerWidget.css',
         'css!bower/highlightjs/styles/default.css',
         'css!./Simulator.css'],
-       function(Util,
-                Q,
+       function(Q,
                 Choice,
                 FormDialog,
                 declParser,

--- a/src/visualizers/widgets/HFSMViz/WebGMEHost.js
+++ b/src/visualizers/widgets/HFSMViz/WebGMEHost.js
@@ -1,0 +1,121 @@
+/**
+ * HostServices over the WebGME client UI.
+ *
+ * This and WebGMEBackend are the only files under HFSMViz/ that know
+ * about WebGME: the backend for the model, this for the surrounding
+ * application. Everything WebGME-only that used to be a top-level
+ * dependency of the widget -- its context menu, its document editor,
+ * its part-browser drag and drop -- lives here, which is what lets
+ * the widget itself load in a host that has none of them.
+ *
+ * See src/common/viz/HostServices.js for the contract.
+ */
+define([
+  'hfsm/viz/HostServices',
+  'js/Constants',
+  'js/Controls/ContextMenu',
+  'js/DragDrop/DropTarget',
+  'js/DragDrop/DragConstants',
+  'decorators/DocumentDecorator/DiagramDesigner/DocumentEditorDialog',
+], function (HostServices, CONSTANTS, ContextMenu, dropTarget,
+             DROP_CONSTANTS, DocumentEditorDialog) {
+  'use strict';
+
+  /**
+   * @param client        the WebGME client, for branch events
+   * @param webgmeGlobal  WebGMEGlobal, for the shared selection state
+   */
+  function WebGMEHost(client, webgmeGlobal) {
+    this._client = client;
+    this._global = webgmeGlobal;
+  }
+
+  WebGMEHost.prototype.contextMenu = function (items, onSelect, position) {
+    var menu = new ContextMenu({
+      items: items,
+      callback: function (key) {
+        if (onSelect) onSelect(key);
+      },
+    });
+    menu.show(position || { x: 200, y: 200 });
+  };
+
+  WebGMEHost.prototype.editDocument = function (text, onSave) {
+    var dialog = new DocumentEditorDialog();
+    dialog.initialize(text, onSave);
+    dialog.show();
+  };
+
+  // WebGME's drag payload keys its lists by constants; the widget is
+  // given the plain { items, effects } the contract promises
+  function normalize(dragInfo) {
+    if (!dragInfo) return { items: [], effects: [] };
+    return {
+      items: dragInfo[DROP_CONSTANTS.DRAG_ITEMS] || [],
+      effects: dragInfo[DROP_CONSTANTS.DRAG_EFFECTS] || [],
+    };
+  }
+
+  WebGMEHost.prototype.makeDroppable = function (element, handlers) {
+    dropTarget.makeDroppable(element, {
+      over: function (event, dragInfo) {
+        if (handlers.over) handlers.over(event, normalize(dragInfo));
+      },
+      out: function (event, dragInfo) {
+        if (handlers.out) handlers.out(event, normalize(dragInfo));
+      },
+      drop: function (event, dragInfo) {
+        if (handlers.drop) handlers.drop(event, normalize(dragInfo));
+      },
+    });
+    return function () {
+      dropTarget.destroyDroppable(element);
+    };
+  };
+
+  /**
+   * Optional in the contract: branch changes and the shared
+   * active-selection state are properties of the WebGME application,
+   * not of the model. A host without either simply does not provide
+   * this, and the widget skips it.
+   *
+   * @return a function that unsubscribes everything
+   */
+  WebGMEHost.prototype.observe = function (handlers) {
+    var self = this;
+    var client = this._client;
+    var selectionEvent = 'change:' + CONSTANTS.STATE_ACTIVE_SELECTION;
+    var onSelection = function (model, selection, opts) {
+      if (handlers.selectionChanged) handlers.selectionChanged(model, selection, opts);
+    };
+    var onBranch = function (args) {
+      if (handlers.branchChanged) handlers.branchChanged(args);
+    };
+    var onBranchStatus = function (args) {
+      if (handlers.branchStatusChanged) handlers.branchStatusChanged(args);
+    };
+
+    if (this._global && this._global.State) {
+      this._global.State.on(selectionEvent, onSelection, this);
+    }
+    if (client) {
+      client.addEventListener(client.CONSTANTS.BRANCH_CHANGED, onBranch);
+      client.addEventListener(client.CONSTANTS.BRANCH_STATUS_CHANGED, onBranchStatus);
+    }
+
+    return function () {
+      if (self._global && self._global.State) {
+        self._global.State.off(selectionEvent, onSelection, self);
+      }
+      if (client) {
+        client.removeEventListener(client.CONSTANTS.BRANCH_CHANGED, onBranch);
+        client.removeEventListener(client.CONSTANTS.BRANCH_STATUS_CHANGED, onBranchStatus);
+      }
+    };
+  };
+
+  return function (client, webgmeGlobal) {
+    return HostServices.assertImplements(
+      new WebGMEHost(client, webgmeGlobal), 'WebGMEHost');
+  };
+});

--- a/test/simulatorStandalone.spec.js
+++ b/test/simulatorStandalone.spec.js
@@ -106,6 +106,62 @@ describe('simulator outside WebGME', function() {
     });
   });
 
+  it('keeps the whole widget dependency closure free of WebGME', function() {
+    // The widget itself cannot be loaded here (cytoscape needs a
+    // DOM), so this walks the define([...]) lists statically instead:
+    // start at the widget and follow every relative / hfsm dependency,
+    // asserting no WebGME-only module id appears anywhere in the
+    // closure. A single one of those is enough to stop the module
+    // loading in a host that is not WebGME, which is the whole point.
+    var start = 'src/visualizers/widgets/HFSMViz/HFSMVizWidget.js';
+    var seen = {};
+    var offenders = [];
+
+    function depsOf(file) {
+      var text = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+      var body = text.slice(text.indexOf('define('));
+      var list = body.slice(0, body.indexOf(']'));
+      var ids = [];
+      list.replace(/['"]([^'"]+)['"]/g, function(_, id) { ids.push(id); return _; });
+      return ids;
+    }
+
+    function walk(file) {
+      if (seen[file]) return;
+      seen[file] = true;
+      depsOf(file).forEach(function(id) {
+        // strip loader plugins: what they load is markup / styling
+        var bare = id.replace(/^(text|css)!/, '');
+        // 'js/' and 'client/' are WebGME's own client modules
+        if (/^(js|client)\//.test(bare)) {
+          offenders.push(file + ' -> ' + id);
+          return;
+        }
+        var next = null;
+        if (bare.charAt(0) === '.') {
+          next = path.join(path.dirname(file), bare);
+        } else if (bare.indexOf('hfsm/') === 0) {
+          next = path.join('src/common', bare.slice('hfsm/'.length));
+        } else if (bare.indexOf('decorators/') === 0) {
+          // 'decorators/' is THIS repo's src/decorators, which a host
+          // maps for itself exactly like it maps 'hfsm/'
+          next = path.join('src', bare);
+        }
+        if (!next) return;   // third-party: vendorable, not WebGME
+        if (!/\.[a-z]+$/.test(next)) next += '.js';
+        if (fs.existsSync(path.join(repoRoot, next))) walk(next);
+      });
+    }
+
+    walk(start);
+    assert.deepStrictEqual(offenders, [],
+      'the widget must not reach a WebGME-only module:\n  ' +
+      offenders.join('\n  '));
+    assert.ok(Object.keys(seen).length > 3,
+              'the walk should have followed several modules, saw ' +
+              Object.keys(seen).length);
+  });
+
   it('names no WebGME module in its dependency list', function() {
     // belt and braces: the loader test above can only catch what it
     // reaches, and a lazily-required id would slip past it

--- a/test/simulatorStandalone.spec.js
+++ b/test/simulatorStandalone.spec.js
@@ -19,13 +19,6 @@ var path = require('path');
 
 var repoRoot = path.resolve(__dirname, '..');
 
-function firstExisting(candidates, what) {
-  for (var i = 0; i < candidates.length; i++) {
-    if (fs.existsSync(candidates[i] + '.js')) return candidates[i];
-  }
-  throw new Error('cannot find ' + what + '; run npm install');
-}
-
 function standaloneContext(name) {
   var requirejs = require('requirejs');
   return requirejs.config({
@@ -36,25 +29,14 @@ function standaloneContext(name) {
       // the HFSM modules, exactly as any host maps them
       hfsm: path.join(repoRoot, 'src/common'),
 
-      // third-party runtime deps -- vendorable, not WebGME
-      q: firstExisting([path.join(repoRoot, 'node_modules/q/q')], 'q'),
-      'bower/mustache.js/mustache.min': firstExisting([
-        path.join(repoRoot, 'bower_components/mustache.js/mustache.min'),
-        path.join(repoRoot, 'node_modules/mustache/mustache.min'),
-      ], 'mustache'),
-      'bower/highlightjs/highlight.pack.min': firstExisting([
-        path.join(repoRoot, 'bower_components/highlightjs/highlight.pack.min'),
-      ], 'highlight.js'),
-      underscore: firstExisting([
-        path.join(repoRoot, 'node_modules/underscore/underscore-umd'),
-        path.join(repoRoot, 'node_modules/underscore/underscore'),
-      ], 'underscore'),
-      'bower/handlebars/handlebars.min': firstExisting([
-        path.join(repoRoot, 'bower_components/handlebars/handlebars.min'),
-        path.join(repoRoot, 'node_modules/handlebars/dist/handlebars.min'),
-      ], 'handlebars'),
+      // Third-party runtime deps, stubbed: see test/stubs/lib.js.
+      // They are vendorable by definition, so whether they happen to
+      // be installed says nothing about the question being asked.
+      q: 'test/stubs/q',
+      'bower/mustache.js/mustache.min': 'test/stubs/mustache',
+      'bower/highlightjs/highlight.pack.min': 'test/stubs/highlight',
 
-      // NOTE: deliberately absent -- js/*, decorators/*, WebGMEGlobal
+      // NOTE: deliberately absent -- js/*, client/*, WebGMEGlobal
     },
     map: {
       '*': {
@@ -173,7 +155,9 @@ describe('simulator outside WebGME', function() {
     ];
     // `decorators/` is this repo's own (src/decorators), so a css!
     // include of it is not a WebGME dependency
-    var webgmeOnly = /'(js\/[^']*|client\/[^']*)'|\bWebGMEGlobal\b/;
+    // both quote styles: this file uses single quotes, the widget
+    // uses double, and a scan that only saw one would be no scan
+    var webgmeOnly = /['"](js\/[^'"]*|client\/[^'"]*)['"]|\bWebGMEGlobal\b/;
     files.forEach(function(file) {
       var text = fs.readFileSync(path.join(repoRoot, file), 'utf8');
       var hit = text.match(webgmeOnly);

--- a/test/simulatorStandalone.spec.js
+++ b/test/simulatorStandalone.spec.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * The simulator is meant to run outside WebGME -- that is the whole
+ * point of ModelBackend. This loads it the way a non-WebGME host
+ * would: a requirejs context with NO WebGME module paths configured
+ * at all, so any lingering `js/...` or `decorators/...` dependency
+ * fails to resolve instead of quietly working because WebGME happened
+ * to be serving it.
+ *
+ * `text!` and `css!` are stubbed rather than mapped: a host still has
+ * to supply those plugins, but what they load is markup and styling,
+ * not WebGME behaviour.
+ */
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+
+var repoRoot = path.resolve(__dirname, '..');
+
+function firstExisting(candidates, what) {
+  for (var i = 0; i < candidates.length; i++) {
+    if (fs.existsSync(candidates[i] + '.js')) return candidates[i];
+  }
+  throw new Error('cannot find ' + what + '; run npm install');
+}
+
+function standaloneContext(name) {
+  var requirejs = require('requirejs');
+  return requirejs.config({
+    context: name,
+    baseUrl: repoRoot,
+    nodeRequire: require,
+    paths: {
+      // the HFSM modules, exactly as any host maps them
+      hfsm: path.join(repoRoot, 'src/common'),
+
+      // third-party runtime deps -- vendorable, not WebGME
+      q: firstExisting([path.join(repoRoot, 'node_modules/q/q')], 'q'),
+      'bower/mustache.js/mustache.min': firstExisting([
+        path.join(repoRoot, 'bower_components/mustache.js/mustache.min'),
+        path.join(repoRoot, 'node_modules/mustache/mustache.min'),
+      ], 'mustache'),
+      'bower/highlightjs/highlight.pack.min': firstExisting([
+        path.join(repoRoot, 'bower_components/highlightjs/highlight.pack.min'),
+      ], 'highlight.js'),
+      underscore: firstExisting([
+        path.join(repoRoot, 'node_modules/underscore/underscore-umd'),
+        path.join(repoRoot, 'node_modules/underscore/underscore'),
+      ], 'underscore'),
+      'bower/handlebars/handlebars.min': firstExisting([
+        path.join(repoRoot, 'bower_components/handlebars/handlebars.min'),
+        path.join(repoRoot, 'node_modules/handlebars/dist/handlebars.min'),
+      ], 'handlebars'),
+
+      // NOTE: deliberately absent -- js/*, decorators/*, WebGMEGlobal
+    },
+    map: {
+      '*': {
+        text: 'test/stubs/text',
+        css: 'test/stubs/css',
+      },
+    },
+  });
+}
+
+describe('simulator outside WebGME', function() {
+
+  it('loads with no WebGME module paths configured', function() {
+    this.timeout(10000);
+    var req = standaloneContext('standalone-sim');
+    return new Promise(function(resolve, reject) {
+      req(['src/visualizers/widgets/HFSMViz/Simulator/Simulator'],
+          function(Simulator) {
+            assert.strictEqual(typeof Simulator, 'function',
+                               'Simulator should be a constructor');
+            resolve();
+          },
+          function(err) {
+            reject(new Error('Simulator still depends on something ' +
+                             'WebGME-only: ' + err.message));
+          });
+    });
+  });
+
+  it('loads its dialogs the same way', function() {
+    this.timeout(10000);
+    var req = standaloneContext('standalone-dialogs');
+    return new Promise(function(resolve, reject) {
+      req(['src/visualizers/widgets/HFSMViz/Simulator/Choice',
+           'src/visualizers/widgets/HFSMViz/Simulator/FormDialog',
+           'src/visualizers/widgets/HFSMViz/Dialog/Dialog'],
+          function(Choice, FormDialog, Dialog) {
+            [['Choice', Choice], ['FormDialog', FormDialog],
+             ['Dialog', Dialog]].forEach(function(pair) {
+               assert.strictEqual(typeof pair[1], 'function',
+                                  pair[0] + ' should be a constructor');
+             });
+            resolve();
+          },
+          function(err) {
+            reject(new Error('a dialog still depends on something ' +
+                             'WebGME-only: ' + err.message));
+          });
+    });
+  });
+
+  it('names no WebGME module in its dependency list', function() {
+    // belt and braces: the loader test above can only catch what it
+    // reaches, and a lazily-required id would slip past it
+    var files = [
+      'src/visualizers/widgets/HFSMViz/Simulator/Simulator.js',
+      'src/visualizers/widgets/HFSMViz/Simulator/Choice.js',
+      'src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js',
+      'src/visualizers/widgets/HFSMViz/Dialog/Dialog.js',
+    ];
+    // `decorators/` is this repo's own (src/decorators), so a css!
+    // include of it is not a WebGME dependency
+    var webgmeOnly = /'(js\/[^']*|client\/[^']*)'|\bWebGMEGlobal\b/;
+    files.forEach(function(file) {
+      var text = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+      var hit = text.match(webgmeOnly);
+      assert.ok(!hit, file + ' references WebGME-only ' + (hit && hit[0]));
+    });
+  });
+});

--- a/test/simulatorStandalone.spec.js
+++ b/test/simulatorStandalone.spec.js
@@ -10,7 +10,9 @@
  *
  * `text!` and `css!` are stubbed rather than mapped: a host still has
  * to supply those plugins, but what they load is markup and styling,
- * not WebGME behaviour.
+ * not WebGME behaviour. The third-party runtime libraries are stubbed
+ * for the same reason -- see test/stubs/{text,css,q,mustache,
+ * highlight}.js, each of which documents why.
  */
 
 var assert = require('assert');
@@ -29,9 +31,10 @@ function standaloneContext(name) {
       // the HFSM modules, exactly as any host maps them
       hfsm: path.join(repoRoot, 'src/common'),
 
-      // Third-party runtime deps, stubbed: see test/stubs/lib.js.
-      // They are vendorable by definition, so whether they happen to
-      // be installed says nothing about the question being asked.
+      // Third-party runtime deps, stubbed (one file each -- see the
+      // note in test/stubs/q.js). They are vendorable by definition,
+      // so whether they happen to be installed says nothing about
+      // the question being asked.
       q: 'test/stubs/q',
       'bower/mustache.js/mustache.min': 'test/stubs/mustache',
       'bower/highlightjs/highlight.pack.min': 'test/stubs/highlight',
@@ -144,10 +147,15 @@ describe('simulator outside WebGME', function() {
               Object.keys(seen).length);
   });
 
-  it('names no WebGME module in its dependency list', function() {
-    // belt and braces: the loader test above can only catch what it
-    // reaches, and a lazily-required id would slip past it
+  it('mentions no WebGME module anywhere in its source', function() {
+    // Belt and braces. The two tests above only see what they can
+    // reach: one loads the modules, the other reads define([...])
+    // lists. Neither would notice a lazy require('js/...') or a bare
+    // WebGMEGlobal buried in a function body -- least of all in the
+    // widget, which is the main thing being decoupled and which the
+    // loader test cannot even run (cytoscape needs a DOM).
     var files = [
+      'src/visualizers/widgets/HFSMViz/HFSMVizWidget.js',
       'src/visualizers/widgets/HFSMViz/Simulator/Simulator.js',
       'src/visualizers/widgets/HFSMViz/Simulator/Choice.js',
       'src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js',

--- a/test/stubs/css.js
+++ b/test/stubs/css.js
@@ -1,0 +1,11 @@
+/**
+ * requirejs `css!` plugin stub: there is no document to style in
+ * node. A host outside WebGME supplies a real one (require-css in the
+ * browser).
+ */
+define([], function () {
+  'use strict';
+  return {
+    load: function (name, parentRequire, onload) { onload(); },
+  };
+});

--- a/test/stubs/highlight.js
+++ b/test/stubs/highlight.js
@@ -1,0 +1,22 @@
+/**
+ * Stand-in for a third-party runtime library (highlight).
+ *
+ * The standalone-loading tests ask one question -- can these modules
+ * load without WebGME -- and whether a vendorable library happens to
+ * be installed says nothing about it. Stubbing keeps the test
+ * hermetic: no bower_components, and no npm packages beyond the ones
+ * the generator tests already install.
+ *
+ * These libraries are used at RUNTIME only, never while the modules
+ * are being defined. Deliberately an empty object rather than
+ * something permissive: if that ever changes, the test fails loudly
+ * and this stub gets updated, instead of passing on a lie.
+ *
+ * One file per library on purpose -- pointing several requirejs
+ * module ids at a single stub file hangs the loader, which resolves
+ * the anonymous define() once and leaves the other ids waiting.
+ */
+define([], function () {
+  'use strict';
+  return {};
+});

--- a/test/stubs/mustache.js
+++ b/test/stubs/mustache.js
@@ -1,0 +1,22 @@
+/**
+ * Stand-in for a third-party runtime library (mustache).
+ *
+ * The standalone-loading tests ask one question -- can these modules
+ * load without WebGME -- and whether a vendorable library happens to
+ * be installed says nothing about it. Stubbing keeps the test
+ * hermetic: no bower_components, and no npm packages beyond the ones
+ * the generator tests already install.
+ *
+ * These libraries are used at RUNTIME only, never while the modules
+ * are being defined. Deliberately an empty object rather than
+ * something permissive: if that ever changes, the test fails loudly
+ * and this stub gets updated, instead of passing on a lie.
+ *
+ * One file per library on purpose -- pointing several requirejs
+ * module ids at a single stub file hangs the loader, which resolves
+ * the anonymous define() once and leaves the other ids waiting.
+ */
+define([], function () {
+  'use strict';
+  return {};
+});

--- a/test/stubs/q.js
+++ b/test/stubs/q.js
@@ -1,0 +1,22 @@
+/**
+ * Stand-in for a third-party runtime library (q).
+ *
+ * The standalone-loading tests ask one question -- can these modules
+ * load without WebGME -- and whether a vendorable library happens to
+ * be installed says nothing about it. Stubbing keeps the test
+ * hermetic: no bower_components, and no npm packages beyond the ones
+ * the generator tests already install.
+ *
+ * These libraries are used at RUNTIME only, never while the modules
+ * are being defined. Deliberately an empty object rather than
+ * something permissive: if that ever changes, the test fails loudly
+ * and this stub gets updated, instead of passing on a lie.
+ *
+ * One file per library on purpose -- pointing several requirejs
+ * module ids at a single stub file hangs the loader, which resolves
+ * the anonymous define() once and leaves the other ids waiting.
+ */
+define([], function () {
+  'use strict';
+  return {};
+});

--- a/test/stubs/text.js
+++ b/test/stubs/text.js
@@ -1,0 +1,20 @@
+/**
+ * requirejs `text!` plugin stub for the standalone-loading tests: a
+ * host outside WebGME supplies its own (the playground vendors
+ * requirejs-text). Loading the real markup is not what those tests
+ * are about -- reaching a WebGME module is.
+ */
+define([], function () {
+  'use strict';
+  var fs = require('fs');
+  var path = require('path');
+  return {
+    load: function (name, parentRequire, onload) {
+      try {
+        onload(fs.readFileSync(path.resolve(parentRequire.toUrl(name)), 'utf8'));
+      } catch (e) {
+        onload('');   // markup is not under test here
+      }
+    },
+  };
+});

--- a/test/stubs/text.js
+++ b/test/stubs/text.js
@@ -1,20 +1,19 @@
 /**
- * requirejs `text!` plugin stub for the standalone-loading tests: a
- * host outside WebGME supplies its own (the playground vendors
- * requirejs-text). Loading the real markup is not what those tests
- * are about -- reaching a WebGME module is.
+ * requirejs `text!` plugin stub.
+ *
+ * Returns empty text rather than reading the file. These tests ask
+ * whether the modules can be RESOLVED without WebGME; none of them
+ * touches its markup while being defined, so the actual content is
+ * irrelevant here and a host outside WebGME supplies a real plugin
+ * anyway (the playground vendors requirejs-text).
+ *
+ * This also sidesteps a trap: inside an AMD factory, `require` is the
+ * loader, not node's, so a stub that reached for `fs` would depend on
+ * which one happened to be in scope.
  */
 define([], function () {
   'use strict';
-  var fs = require('fs');
-  var path = require('path');
   return {
-    load: function (name, parentRequire, onload) {
-      try {
-        onload(fs.readFileSync(path.resolve(parentRequire.toUrl(name)), 'utf8'));
-      } catch (e) {
-        onload('');   // markup is not under test here
-      }
-    },
+    load: function (name, parentRequire, onload) { onload(''); },
   };
 });


### PR DESCRIPTION
Second step of the viz decoupling. Phase A put the model behind `ModelBackend`; this removes the last reason the visualizer could only run inside WebGME.

## What was still tying it down

**The simulator:** nothing, as it turned out. It, `Choice`, `FormDialog` and the add-child `Dialog` each imported `js/util` and none of them called it — four dead dependencies that made the subtree *look* WebGME-bound after it had stopped being so.

**The widget:** four real ones, all top-level, which is what matters — a top-level dependency fails to resolve long before any of it runs, so the widget could not load in another host however little of it was used.

| dependency | what for |
| --- | --- |
| `js/Controls/ContextMenu` | context menus (1 call site) |
| `decorators/.../DocumentEditorDialog` | editing documentation (1 call site) |
| `js/DragDrop/DropTarget` + `DragConstants` | dragging from the part browser |
| `js/Constants` | the shared active-selection state |

## HostServices

The counterpart to `ModelBackend`: that one abstracts the **model**, this one abstracts the **surrounding application**. Three methods — `contextMenu`, `editDocument`, `makeDroppable` — plus an optional `observe()` for hosts that have branches and a shared selection, which WebGME does and a plain page does not. `HostServices.none()` is a host that offers none of it, which is all a read-only view needs.

`WebGMEHost` implements it. With `WebGMEBackend` it is now the only place under `HFSMViz/` that mentions WebGME, and **neither is reachable from the widget** — defaulting to them inside the widget would put them straight back in its dependency list. The panel wires both up, which is the right place: a panel *is* the WebGME integration point.

Drag payloads are normalized on the way in, so the widget reads `{items, effects}` instead of indexing WebGME's drag constants.

## Enforced, not asserted

`test/simulatorStandalone.spec.js`:

- loads the simulator and its dialogs through a requirejs context with **no WebGME paths configured at all**, so a stray `js/...` fails to resolve rather than quietly working because WebGME happened to be serving it
- walks the widget's whole `define()` closure and fails on any `js/` or `client/` id it can reach (`decorators/` is this repo's own `src/decorators`, which a host maps like it maps `hfsm/`)
- scans the sources too, since a lazily-required id would slip past a loader test

Each guard was confirmed to fail when a WebGME import is put back.

## Unchanged for WebGME

Verified in the running container: graph, simulator, event buttons, variables and the guard dialogs all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy