### PR TITLE
Phase C: the visualizer runs in the playground

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,17 @@ jobs:
           npm install --no-save --no-package-lock --ignore-scripts
           requirejs requirejs-text handlebars underscore
 
+      # The playground ships the visualizer, so it needs the same
+      # front-end libraries WebGME serves -- at the SAME versions,
+      # which is the point of vendoring them rather than picking
+      # replacements. bower.json pins the cytoscape family; the rest
+      # (jquery, bootstrap, require-css, font-awesome, q) come from
+      # webgme's own dependencies, exactly as they do at runtime.
+      - name: Install the visualizer's front-end libraries
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts webgme bower
+          ./node_modules/.bin/bower install --allow-root
+
       - name: Build the playground
         run: ./scripts/build-web.sh
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,15 @@ copy of them: `resolveModel` rejects ill-typed containment and
 transition endpoints, and `LocalBackend` (the WebGME-free
 `ModelBackend`) offers exactly the types the editor would offer.
 
+## Model layout travels with the model
+
+Laying out a state chart is real work, so `position` is part of the
+model format rather than something the editor keeps to itself. The
+`SoftwareGenerator` plugin writes `<Machine>_model.json` next to the
+generated code with the layout as you left it; the CLI and the
+playground read it back, so the same model draws the same way
+everywhere. Models with no positions are arranged automatically.
+
 ## Validation & Testing
 
 Models are validated before generation (structure, names, events,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -62,10 +62,29 @@ parent paths derived from paths). See `test/fixtures/*.json` and
     "/p/m/i":    { "name": "Initial", "type": "Initial" },
     "/p/m/ti":   { "name": "init", "type": "External Transition",
                    "pointers": { "src": "/p/m/i", "dst": "/p/m/S1" } },
-    "/p/m/S1":   { "name": "S1", "type": "State", "Timer Period": 0.1 }
+    "/p/m/S1":   { "name": "S1", "type": "State", "Timer Period": 0.1,
+                   "position": { "x": 240, "y": 120 } }
   }
 }
 ```
+
+### Layout
+
+`position` (`{ x, y }`, in pixels) is part of the format, not an
+editor detail. Arranging a state chart so that it reads well is real
+work, and a model that does not carry the arrangement loses it every
+time it leaves the editor -- and then draws differently in WebGME and
+in the playground.
+
+The `SoftwareGenerator` plugin writes `<Machine>_model.json` alongside
+the generated code, carrying the layout as the editor left it. Feed
+that file to the CLI or drop it into the playground and the diagram
+comes out the same as it looks in WebGME.
+
+Models without positions still load: the playground arranges them
+automatically, and the CLI ignores the field entirely (no generated
+output depends on it). A malformed `position` is rejected rather than
+reaching the diagram as a `NaN` coordinate.
 
 `Library` roots generate code and interop exports exactly like
 `State Machine` roots, but no test bench (a library is not an

--- a/examples/Complex.json
+++ b/examples/Complex.json
@@ -1,0 +1,707 @@
+{
+  "root": "/c",
+  "namespace": "espp::state_machine",
+  "objects": {
+    "/c": {
+      "name": "Complex",
+      "type": "State Machine",
+      "position": {
+        "x": 450,
+        "y": 238
+      },
+      "Declarations": "bool goToEnd      = false;\nbool goToChoice   = true;\nbool goToHistory  = false;\nbool nextState    = false;\nbool killedState  = false;\nbool someGuard    = true;\nbool someTest     = true;\n\nint someNumber = 40;\nint someValue  = 50;",
+      "Includes": "#include <stdio.h>"
+    },
+    "/c/3": {
+      "name": "EVENT1",
+      "type": "Event",
+      "position": {
+        "x": 100,
+        "y": 100
+      }
+    },
+    "/c/3/a": {
+      "name": "last_time",
+      "type": "Field",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Default": "0"
+    },
+    "/c/A": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/G",
+        "src": "/c/T"
+      }
+    },
+    "/c/C": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/c/v/G",
+        "src": "/c/T"
+      }
+    },
+    "/c/E": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/c/T",
+        "src": "/c/v"
+      }
+    },
+    "/c/F": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/G",
+        "src": "/c/v"
+      }
+    },
+    "/c/G": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 457,
+        "y": 665
+      }
+    },
+    "/c/I": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 343,
+        "y": 189
+      },
+      "Event": "EVENT4",
+      "Guard": "someTest",
+      "pointers": {
+        "dst": "/c/X",
+        "src": "/c/Y"
+      }
+    },
+    "/c/L": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "ENDEVENT",
+      "pointers": {
+        "dst": "/c/Y",
+        "src": "/c/T"
+      }
+    },
+    "/c/Q": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT4",
+      "pointers": {
+        "dst": "/c/T/o",
+        "src": "/c/v"
+      }
+    },
+    "/c/T": {
+      "name": "State3",
+      "type": "State",
+      "position": {
+        "x": 596,
+        "y": 481
+      }
+    },
+    "/c/T/0": {
+      "name": "ChildState2",
+      "type": "State",
+      "position": {
+        "x": 617,
+        "y": 504
+      },
+      "Timer Period": 0.1
+    },
+    "/c/T/A": {
+      "name": "Shallow History Pseudostate",
+      "type": "Shallow History Pseudostate",
+      "position": {
+        "x": 495,
+        "y": 404
+      }
+    },
+    "/c/T/I": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/T/W",
+        "src": "/c/T/v"
+      }
+    },
+    "/c/T/L": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/c/T/0",
+        "src": "/c/T/W"
+      }
+    },
+    "/c/T/W": {
+      "name": "ChildState",
+      "type": "State",
+      "position": {
+        "x": 564,
+        "y": 433
+      },
+      "Timer Period": 0.1
+    },
+    "/c/T/h": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "ENDEVENT",
+      "pointers": {
+        "dst": "/c/T/z",
+        "src": "/c/T/0"
+      }
+    },
+    "/c/T/j": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/c/T/w",
+        "src": "/c/T/0"
+      }
+    },
+    "/c/T/o": {
+      "name": "Deep History Pseudostate",
+      "type": "Deep History Pseudostate",
+      "position": {
+        "x": 510,
+        "y": 422
+      }
+    },
+    "/c/T/p": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/c/T/W",
+        "src": "/c/T/w"
+      }
+    },
+    "/c/T/v": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 527,
+        "y": 431
+      }
+    },
+    "/c/T/w": {
+      "name": "ChildState3",
+      "type": "State",
+      "position": {
+        "x": 677,
+        "y": 429
+      },
+      "Timer Period": 0.1
+    },
+    "/c/T/z": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 618,
+        "y": 557
+      }
+    },
+    "/c/X": {
+      "name": "Choice Pseudostate",
+      "type": "Choice Pseudostate",
+      "position": {
+        "x": 495,
+        "y": 298
+      }
+    },
+    "/c/Y": {
+      "name": "State 1",
+      "type": "State",
+      "position": {
+        "x": 583,
+        "y": 221
+      },
+      "Entry": "int a = 2;\nprintf(\"SerialTask :: initializing State 1\\n\");",
+      "Exit": "printf(\"Exiting State 1\\n\");",
+      "Tick": "printf(\"SerialTask::State 1::tick()\\n\");",
+      "Timer Period": 0.1
+    },
+    "/c/Y/X": {
+      "name": "Internal Transition",
+      "type": "Internal Transition",
+      "position": {
+        "x": 511,
+        "y": 229
+      },
+      "Event": "EVENT2",
+      "Guard": "someNumber > someValue"
+    },
+    "/c/Y/t": {
+      "name": "Internal Transition",
+      "type": "Internal Transition",
+      "position": {
+        "x": 511,
+        "y": 214
+      },
+      "Action": "int testVal = 32;\nfor (int i=0; i<testVal; i++) {\n    printf(\"Action iterating: %d\\n\", i);\n}",
+      "Event": "EVENT1",
+      "Guard": "someNumber < someValue"
+    },
+    "/c/Z": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 440,
+        "y": 221
+      }
+    },
+    "/c/h": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "goToHistory",
+      "pointers": {
+        "dst": "/c/T/A",
+        "src": "/c/X"
+      }
+    },
+    "/c/k": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 343,
+        "y": 189
+      },
+      "Guard": "nextState",
+      "pointers": {
+        "dst": "/c/v",
+        "src": "/c/X"
+      }
+    },
+    "/c/m": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 343,
+        "y": 189
+      },
+      "pointers": {
+        "dst": "/c/Y",
+        "src": "/c/Z"
+      }
+    },
+    "/c/r": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/T",
+        "src": "/c/X"
+      }
+    },
+    "/c/t": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/c/T/A",
+        "src": "/c/v"
+      }
+    },
+    "/c/v": {
+      "name": "State 2",
+      "type": "State",
+      "position": {
+        "x": 294,
+        "y": 455
+      }
+    },
+    "/c/v/2": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/v/z",
+        "src": "/c/v/U"
+      }
+    },
+    "/c/v/E": {
+      "name": "Deep History Pseudostate",
+      "type": "Deep History Pseudostate",
+      "position": {
+        "x": 406,
+        "y": 616
+      }
+    },
+    "/c/v/F": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/v/U",
+        "src": "/c/v/z"
+      }
+    },
+    "/c/v/G": {
+      "name": "Shallow History Pseudostate",
+      "type": "Shallow History Pseudostate",
+      "position": {
+        "x": 402,
+        "y": 590
+      }
+    },
+    "/c/v/K": {
+      "name": "ChildState",
+      "type": "State",
+      "position": {
+        "x": 213,
+        "y": 557
+      },
+      "Timer Period": 0.1
+    },
+    "/c/v/P": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "Guard": "someGuard",
+      "pointers": {
+        "dst": "/c/v/K",
+        "src": "/c/v/z"
+      }
+    },
+    "/c/v/S": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/c/v/e",
+        "src": "/c/v/K"
+      }
+    },
+    "/c/v/U": {
+      "name": "Choice Pseudostate",
+      "type": "Choice Pseudostate",
+      "position": {
+        "x": 307,
+        "y": 469
+      }
+    },
+    "/c/v/W": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/c/v/z",
+        "src": "/c/v/e"
+      }
+    },
+    "/c/v/e": {
+      "name": "ChildState2",
+      "type": "State",
+      "position": {
+        "x": 387,
+        "y": 555
+      },
+      "Timer Period": 0.1
+    },
+    "/c/v/g": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "killedState",
+      "pointers": {
+        "dst": "/c/v/w",
+        "src": "/c/v/U"
+      }
+    },
+    "/c/v/j": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 179,
+        "y": 559
+      }
+    },
+    "/c/v/u": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/v/K",
+        "src": "/c/v/j"
+      }
+    },
+    "/c/v/w": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 309,
+        "y": 512
+      }
+    },
+    "/c/v/z": {
+      "name": "ChildState3",
+      "type": "State",
+      "position": {
+        "x": 181,
+        "y": 331
+      }
+    },
+    "/c/v/z/0": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 343,
+        "y": 425
+      }
+    },
+    "/c/v/z/6": {
+      "name": "Grand",
+      "type": "State",
+      "position": {
+        "x": 224,
+        "y": 427
+      },
+      "Timer Period": 0.1
+    },
+    "/c/v/z/8": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/v/z/6",
+        "src": "/c/v/z/D"
+      }
+    },
+    "/c/v/z/9": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "ENDEVENT",
+      "pointers": {
+        "dst": "/c/v/z/0",
+        "src": "/c/v/z/c"
+      }
+    },
+    "/c/v/z/D": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 188,
+        "y": 429
+      }
+    },
+    "/c/v/z/O": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/c/v/z/c",
+        "src": "/c/v/z/n"
+      }
+    },
+    "/c/v/z/R": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/c/v/z/n",
+        "src": "/c/v/z/c"
+      }
+    },
+    "/c/v/z/a": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/c/v/z/6",
+        "src": "/c/v/z/c"
+      }
+    },
+    "/c/v/z/c": {
+      "name": "Grand2",
+      "type": "State",
+      "position": {
+        "x": 286,
+        "y": 348
+      },
+      "Timer Period": 0.1
+    },
+    "/c/v/z/g": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "goToChoice",
+      "pointers": {
+        "dst": "/c/X",
+        "src": "/c/v/z/n"
+      }
+    },
+    "/c/v/z/j": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "goToEnd",
+      "pointers": {
+        "dst": "/c/v/z/0",
+        "src": "/c/v/z/n"
+      }
+    },
+    "/c/v/z/n": {
+      "name": "Choice Pseudostate",
+      "type": "Choice Pseudostate",
+      "position": {
+        "x": 380,
+        "y": 343
+      }
+    },
+    "/c/v/z/z": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/c/v/z/c",
+        "src": "/c/v/z/6"
+      }
+    },
+    "/c/w": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT4",
+      "pointers": {
+        "dst": "/c/v/E",
+        "src": "/c/T"
+      }
+    },
+    "/c/z": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/c/v",
+        "src": "/c/T"
+      }
+    }
+  }
+}

--- a/examples/Medium.json
+++ b/examples/Medium.json
@@ -1,0 +1,407 @@
+{
+  "root": "/o",
+  "namespace": "espp::state_machine",
+  "objects": {
+    "/o": {
+      "name": "Medium",
+      "type": "State Machine",
+      "position": {
+        "x": 448,
+        "y": 158
+      },
+      "Declarations": "bool reInitialize{false};\nbool goToShallowHistory{false};\nbool goToDeepHistory{true};\nbool cycle{true};"
+    },
+    "/o/6": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "goToShallowHistory",
+      "pointers": {
+        "dst": "/o/r/A",
+        "src": "/o/S"
+      }
+    },
+    "/o/C": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 146,
+        "y": 300
+      }
+    },
+    "/o/D": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "reInitialize",
+      "pointers": {
+        "dst": "/o/r",
+        "src": "/o/S"
+      }
+    },
+    "/o/E": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/r",
+        "src": "/o/C"
+      }
+    },
+    "/o/K": {
+      "name": "State3",
+      "type": "State",
+      "position": {
+        "x": 561,
+        "y": 223
+      },
+      "Timer Period": 0.1
+    },
+    "/o/M": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/o/y",
+        "src": "/o/r"
+      }
+    },
+    "/o/P": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "goToDeepHistory",
+      "pointers": {
+        "dst": "/o/r/x",
+        "src": "/o/S"
+      }
+    },
+    "/o/S": {
+      "name": "Choice Pseudostate",
+      "type": "Choice Pseudostate",
+      "position": {
+        "x": 461,
+        "y": 150
+      }
+    },
+    "/o/T": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/X",
+        "src": "/o/r"
+      }
+    },
+    "/o/X": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 382,
+        "y": 151
+      }
+    },
+    "/o/c": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/X",
+        "src": "/o/S"
+      }
+    },
+    "/o/g": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/o/q",
+        "src": "/o/K"
+      }
+    },
+    "/o/q": {
+      "name": "State4",
+      "type": "State",
+      "position": {
+        "x": 562,
+        "y": 154
+      },
+      "Timer Period": 0.1
+    },
+    "/o/r": {
+      "name": "State1",
+      "type": "State",
+      "position": {
+        "x": 317,
+        "y": 293
+      }
+    },
+    "/o/r/0": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/o/r/P",
+        "src": "/o/r/6"
+      }
+    },
+    "/o/r/4": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/o/r/O",
+        "src": "/o/r/P"
+      }
+    },
+    "/o/r/6": {
+      "name": "Child2",
+      "type": "State",
+      "position": {
+        "x": 250,
+        "y": 321
+      }
+    },
+    "/o/r/6/7": {
+      "name": "Grand2",
+      "type": "State",
+      "position": {
+        "x": 355,
+        "y": 338
+      },
+      "Timer Period": 0.1
+    },
+    "/o/r/6/B": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/o/r/6/w",
+        "src": "/o/r/6/7"
+      }
+    },
+    "/o/r/6/a": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/r/6/w",
+        "src": "/o/r/6/f"
+      }
+    },
+    "/o/r/6/f": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 256,
+        "y": 339
+      }
+    },
+    "/o/r/6/w": {
+      "name": "Grand",
+      "type": "State",
+      "position": {
+        "x": 286,
+        "y": 339
+      },
+      "Timer Period": 0.1
+    },
+    "/o/r/6/y": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT3",
+      "pointers": {
+        "dst": "/o/r/6/7",
+        "src": "/o/r/6/w"
+      }
+    },
+    "/o/r/7": {
+      "name": "End State",
+      "type": "End State",
+      "position": {
+        "x": 329,
+        "y": 250
+      }
+    },
+    "/o/r/A": {
+      "name": "Shallow History Pseudostate",
+      "type": "Shallow History Pseudostate",
+      "position": {
+        "x": 457,
+        "y": 337
+      }
+    },
+    "/o/r/G": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT1",
+      "pointers": {
+        "dst": "/o/r/6",
+        "src": "/o/r/L"
+      }
+    },
+    "/o/r/L": {
+      "name": "Child1",
+      "type": "State",
+      "position": {
+        "x": 208,
+        "y": 283
+      },
+      "Timer Period": 0.1
+    },
+    "/o/r/O": {
+      "name": "Choice Pseudostate",
+      "type": "Choice Pseudostate",
+      "position": {
+        "x": 329,
+        "y": 280
+      }
+    },
+    "/o/r/P": {
+      "name": "Child3",
+      "type": "State",
+      "position": {
+        "x": 405,
+        "y": 278
+      },
+      "Timer Period": 0.1
+    },
+    "/o/r/Z": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/r/7",
+        "src": "/o/r/O"
+      }
+    },
+    "/o/r/q": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 178,
+        "y": 287
+      }
+    },
+    "/o/r/r": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/o/r/L",
+        "src": "/o/r/q"
+      }
+    },
+    "/o/r/x": {
+      "name": "Deep History Pseudostate",
+      "type": "Deep History Pseudostate",
+      "position": {
+        "x": 437,
+        "y": 280
+      }
+    },
+    "/o/r/y": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Guard": "cycle",
+      "pointers": {
+        "dst": "/o/r/L",
+        "src": "/o/r/O"
+      }
+    },
+    "/o/x": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT4",
+      "pointers": {
+        "dst": "/o/S",
+        "src": "/o/q"
+      }
+    },
+    "/o/y": {
+      "name": "State2",
+      "type": "State",
+      "position": {
+        "x": 555,
+        "y": 298
+      },
+      "Timer Period": 0.1
+    },
+    "/o/z": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "EVENT2",
+      "pointers": {
+        "dst": "/o/K",
+        "src": "/o/y"
+      }
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Example models
+
+The three example machines from the WebGME `examples` seed, exported
+through `SoftwareGenerator` (`<Machine>_model.json`) with their
+hand-made layouts intact.
+
+They are the same machines `sample_code/` was generated from, in the
+portable JSON the CLI and the playground read:
+
+```sh
+node bin/hfsm-gen.js examples/Complex.json -o build/complex -t -e all
+```
+
+Because they carry `position`, the diagram comes out arranged the way
+it is in WebGME rather than auto-laid-out. That is the point: the
+layout is part of the model.
+
+NOTE: these are exported from the *current* state of the models in
+WebGME, which has moved on from `sample_code/` in one place --
+Simple's INPUTEVENT guard now reads the event payload
+(`buttonPressed && data.button_id == 12`) where the committed sample
+still has `_root->buttonPressed`. Regenerating `sample_code/` from
+these is a deliberate step, not something to do by accident.

--- a/examples/Simple.json
+++ b/examples/Simple.json
@@ -1,0 +1,153 @@
+{
+  "root": "/9",
+  "namespace": "espp::state_machine",
+  "objects": {
+    "/9": {
+      "name": "Simple",
+      "type": "State Machine",
+      "position": {
+        "x": 453,
+        "y": 93
+      },
+      "Declarations": "bool buttonPressed{false};",
+      "Includes": "#include <vector>"
+    },
+    "/9/9": {
+      "name": "INPUTEVENT",
+      "type": "Event",
+      "position": {
+        "x": 212,
+        "y": 169
+      }
+    },
+    "/9/9/N": {
+      "name": "button_id",
+      "type": "Field",
+      "position": {
+        "x": 282,
+        "y": 148
+      },
+      "Default": "12"
+    },
+    "/9/9/O": {
+      "name": "press_time_ms",
+      "type": "Field",
+      "position": {
+        "x": 281,
+        "y": 205
+      },
+      "Default": "100"
+    },
+    "/9/A": {
+      "name": "Test",
+      "type": "Event",
+      "position": {
+        "x": 100,
+        "y": 100
+      }
+    },
+    "/9/A/k": {
+      "name": "val",
+      "type": "Field",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Type": "std::vector<int>"
+    },
+    "/9/Y": {
+      "name": "State 1",
+      "type": "State",
+      "position": {
+        "x": 139,
+        "y": 331
+      },
+      "Timer Period": 0.1
+    },
+    "/9/Z": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 94,
+        "y": 336
+      }
+    },
+    "/9/k": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 367,
+        "y": 299
+      },
+      "Event": "INPUTEVENT",
+      "Guard": "buttonPressed && data.button_id == 12",
+      "pointers": {
+        "dst": "/9/v",
+        "src": "/9/Y"
+      }
+    },
+    "/9/m": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 367,
+        "y": 299
+      },
+      "pointers": {
+        "dst": "/9/Y",
+        "src": "/9/Z"
+      }
+    },
+    "/9/v": {
+      "name": "State 2",
+      "type": "State",
+      "position": {
+        "x": 284,
+        "y": 330
+      }
+    },
+    "/9/v/C": {
+      "name": "State",
+      "type": "State",
+      "position": {
+        "x": 305,
+        "y": 335
+      },
+      "Timer Period": 0.1
+    },
+    "/9/v/H": {
+      "name": "Initial",
+      "type": "Initial",
+      "position": {
+        "x": 272,
+        "y": 340
+      }
+    },
+    "/9/v/S": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "pointers": {
+        "dst": "/9/v/C",
+        "src": "/9/v/H"
+      }
+    },
+    "/9/w": {
+      "name": "External Transition",
+      "type": "External Transition",
+      "position": {
+        "x": 100,
+        "y": 100
+      },
+      "Event": "Test",
+      "Guard": "data.val.size()",
+      "pointers": {
+        "dst": "/9/v",
+        "src": "/9/Y"
+      }
+    }
+  }
+}

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -141,8 +141,15 @@ cp "$(find_first "$REPO_ROOT/bower_components/highlightjs/styles/default.css")" 
 # jQuery + bootstrap's modal (the dialogs are bootstrap modals), the
 # require-css plugin (the widget loads its styles through `css!`),
 # and Q for the simulator's promises
-cp "$(find_first "$REPO_ROOT/bower_components/jquery/dist/jquery.min.js" \
-                 "$WG_BOWER/jquery/dist/jquery.min.js")" "$OUT/vendor/jquery.min.js"
+# WebGME's jQuery first, deliberately: that is the one the widget
+# actually runs against in the editor, and it is pinned by webgme's
+# own dependencies. Ours arrives as a floating transitive dependency
+# of the cytoscape plugins -- 3.6.0 here, 3.7.1 on a fresh install --
+# so preferring it would make the playground drift from the editor
+# depending on when someone last ran bower.
+cp "$(find_first "$WG_BOWER/jquery/dist/jquery.min.js" \
+                 "$REPO_ROOT/bower_components/jquery/dist/jquery.min.js")" \
+   "$OUT/vendor/jquery.min.js"
 cp "$(find_first "$WG_BOWER/bootstrap/dist/js/bootstrap.min.js")" "$OUT/vendor/bootstrap.min.js"
 cp "$(find_first "$WG_BOWER/bootstrap/dist/css/bootstrap.min.css")" "$OUT/vendor/bootstrap.min.css"
 cp "$(find_first "$WG_BOWER/require-css/css.min.js")" "$OUT/vendor/css.min.js"

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -174,6 +174,15 @@ for face in woff2 woff ttf; do
 done
 say "visualizer deps (cytoscape + 4 plugins, jquery, bootstrap, require-css, q, mustache, highlight)"
 
+# 3d. the decorator SVGs. The graph styles the End State, the
+#     documentation marker and a collapsed compound node with these,
+#     and the edge-creation handle is one too. WebGME serves them
+#     under assets/DecoratorSVG; the same layout is reproduced here so
+#     the SAME relative paths resolve, with nothing rewritten.
+mkdir -p "$OUT/assets/DecoratorSVG/svgs"
+cp "$REPO_ROOT"/src/svgs/*.svg "$OUT/assets/DecoratorSVG/svgs/"
+say "decorator svgs ($(ls "$OUT/assets/DecoratorSVG/svgs" | wc -l | tr -d ' '))"
+
 # 4. example models -- the same fixtures the test suite generates from,
 #    so the playground can never demo something CI does not cover
 cp "$REPO_ROOT"/test/fixtures/*.json "$OUT/examples/"

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -28,14 +28,19 @@ mkdir -p "$OUT/vendor" "$OUT/examples" \
 echo "building HFSM Playground -> $OUT"
 
 # 1. the page itself
-cp "$REPO_ROOT/web/index.html" "$REPO_ROOT/web/app.js" "$REPO_ROOT/web/app.css" "$OUT/"
+cp "$REPO_ROOT/web/index.html" "$REPO_ROOT/web/app.js" \
+   "$REPO_ROOT/web/app.css" "$REPO_ROOT/web/viz.js" "$OUT/"
 say "page"
 
 # 2. the generator: copied verbatim, never edited for the browser
 cp "$REPO_ROOT"/src/common/*.js "$OUT/src/common/"
+# ... including the viz contracts (ModelBackend, HostServices) and the
+# LocalBackend the playground drives the visualizer through
+mkdir -p "$OUT/src/common/viz"
+cp "$REPO_ROOT"/src/common/viz/*.js "$OUT/src/common/viz/"
 cp -R "$REPO_ROOT/src/plugins/SoftwareGenerator/templates" \
       "$OUT/src/plugins/SoftwareGenerator/templates"
-say "generator ($(ls "$OUT/src/common" | wc -l | tr -d ' ') common modules + templates)"
+say "generator ($(ls "$OUT"/src/common/*.js "$OUT"/src/common/viz/*.js | wc -l | tr -d ' ') common modules + templates)"
 
 # 3. third-party runtime deps (vendored: the app must work offline)
 find_first() {
@@ -75,6 +80,74 @@ cp "$CM_SRC/mode/clike/clike.js"           "$OUT/vendor/codemirror/mode/clike/"
 cp "$CM_SRC/mode/xml/xml.js"               "$OUT/vendor/codemirror/mode/xml/"
 cp "$CM_SRC/mode/shell/shell.js"           "$OUT/vendor/codemirror/mode/shell/"
 say "codemirror (json, c++, xml, shell modes)"
+
+# 3b. the visualizer: the SAME widget and simulator WebGME runs, not a
+#     second implementation. Phase A/B put the model behind
+#     ModelBackend and the host UI behind HostServices, so the widget
+#     itself no longer references WebGME -- which is what makes this
+#     copy possible. Its two WebGME adapters are deliberately NOT
+#     copied: nothing here can load them, and leaving them out keeps
+#     the shipped tree provably free of WebGME.
+VIZ_SRC="$REPO_ROOT/src/visualizers/widgets/HFSMViz"
+mkdir -p "$OUT/src/visualizers/widgets"
+cp -R "$VIZ_SRC" "$OUT/src/visualizers/widgets/HFSMViz"
+rm -f "$OUT/src/visualizers/widgets/HFSMViz/WebGMEBackend.js" \
+      "$OUT/src/visualizers/widgets/HFSMViz/WebGMEHost.js"
+# the simulator styles UML states with this repo's own decorator sheet
+mkdir -p "$OUT/src/decorators/UMLStateMachineDecorator/DiagramDesigner"
+cp "$REPO_ROOT/src/decorators/UMLStateMachineDecorator/DiagramDesigner/UMLStateMachineDecorator.DiagramDesignerWidget.css" \
+   "$OUT/src/decorators/UMLStateMachineDecorator/DiagramDesigner/"
+say "visualizer (widget + simulator, WebGME adapters excluded)"
+
+# 3c. the front-end libraries the visualizer needs. The 'bower/...'
+#     layout is preserved because the widget names its dependencies
+#     that way; a flat copy would need the module ids rewritten, and
+#     rewriting them is exactly the drift this build exists to avoid.
+WG_BOWER="$REPO_ROOT/node_modules/webgme/src/client/bower_components"
+mkdir -p "$OUT/vendor/bower/cytoscape/dist" \
+         "$OUT/vendor/bower/cytoscape-cose-bilkent" \
+         "$OUT/vendor/bower/cytoscape-edgehandles" \
+         "$OUT/vendor/bower/cytoscape-context-menus" \
+         "$OUT/vendor/bower/cytoscape-panzoom" \
+         "$OUT/vendor/bower/mustache.js" \
+         "$OUT/vendor/bower/handlebars" \
+         "$OUT/vendor/bower/blob-util/dist" \
+         "$OUT/vendor/bower/highlightjs/styles"
+
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape/dist/cytoscape.min.js")" \
+   "$OUT/vendor/bower/cytoscape/dist/cytoscape.min.js"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-cose-bilkent/cytoscape-cose-bilkent.js")" \
+   "$OUT/vendor/bower/cytoscape-cose-bilkent/cytoscape-cose-bilkent.js"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-edgehandles/cytoscape-edgehandles.js")" \
+   "$OUT/vendor/bower/cytoscape-edgehandles/cytoscape-edgehandles.js"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-context-menus/cytoscape-context-menus.js")" \
+   "$OUT/vendor/bower/cytoscape-context-menus/cytoscape-context-menus.js"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-context-menus/cytoscape-context-menus.css")" \
+   "$OUT/vendor/bower/cytoscape-context-menus/cytoscape-context-menus.css"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-panzoom/cytoscape-panzoom.js")" \
+   "$OUT/vendor/bower/cytoscape-panzoom/cytoscape-panzoom.js"
+cp "$(find_first "$REPO_ROOT/bower_components/cytoscape-panzoom/cytoscape.js-panzoom.css")" \
+   "$OUT/vendor/bower/cytoscape-panzoom/cytoscape.js-panzoom.css"
+cp "$(find_first "$REPO_ROOT/bower_components/mustache.js/mustache.min.js")" \
+   "$OUT/vendor/bower/mustache.js/mustache.min.js"
+cp "$OUT/vendor/handlebars.min.js" "$OUT/vendor/bower/handlebars/handlebars.min.js"
+cp "$(find_first "$REPO_ROOT/bower_components/blob-util/dist/blob-util.min.js")" \
+   "$OUT/vendor/bower/blob-util/dist/blob-util.min.js"
+cp "$(find_first "$REPO_ROOT/bower_components/highlightjs/highlight.pack.min.js")" \
+   "$OUT/vendor/bower/highlightjs/highlight.pack.min.js"
+cp "$(find_first "$REPO_ROOT/bower_components/highlightjs/styles/default.css")" \
+   "$OUT/vendor/bower/highlightjs/styles/default.css"
+
+# jQuery + bootstrap's modal (the dialogs are bootstrap modals), the
+# require-css plugin (the widget loads its styles through `css!`),
+# and Q for the simulator's promises
+cp "$(find_first "$REPO_ROOT/bower_components/jquery/dist/jquery.min.js" \
+                 "$WG_BOWER/jquery/dist/jquery.min.js")" "$OUT/vendor/jquery.min.js"
+cp "$(find_first "$WG_BOWER/bootstrap/dist/js/bootstrap.min.js")" "$OUT/vendor/bootstrap.min.js"
+cp "$(find_first "$WG_BOWER/bootstrap/dist/css/bootstrap.min.css")" "$OUT/vendor/bootstrap.min.css"
+cp "$(find_first "$WG_BOWER/require-css/css.min.js")" "$OUT/vendor/css.min.js"
+cp "$(find_first "$REPO_ROOT/node_modules/q/q.js")" "$OUT/vendor/q.js"
+say "visualizer deps (cytoscape + 4 plugins, jquery, bootstrap, require-css, q, mustache, highlight)"
 
 # 4. example models -- the same fixtures the test suite generates from,
 #    so the playground can never demo something CI does not cover

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -147,6 +147,24 @@ cp "$(find_first "$WG_BOWER/bootstrap/dist/js/bootstrap.min.js")" "$OUT/vendor/b
 cp "$(find_first "$WG_BOWER/bootstrap/dist/css/bootstrap.min.css")" "$OUT/vendor/bootstrap.min.css"
 cp "$(find_first "$WG_BOWER/require-css/css.min.js")" "$OUT/vendor/css.min.js"
 cp "$(find_first "$REPO_ROOT/node_modules/q/q.js")" "$OUT/vendor/q.js"
+
+# Font Awesome: the simulator's buttons and the graph toolbar are
+# icons, and without the font they render as empty boxes sized for
+# text that is not there. WebGME serves this; a static page has to
+# carry it.
+#
+# The font files keep the 'fonts/' directory the stylesheet expects
+# (it asks for '../fonts/...'). Only the three modern formats are
+# copied: the stylesheet lists eot and svg first and last for very
+# old browsers, which pick them by preference -- anything that can
+# run cytoscape takes the woff2 and never asks for the others.
+FA="$WG_BOWER/font-awesome"
+mkdir -p "$OUT/vendor/font-awesome/css" "$OUT/vendor/font-awesome/fonts"
+cp "$(find_first "$FA/css/font-awesome.min.css")" "$OUT/vendor/font-awesome/css/"
+for face in woff2 woff ttf; do
+  cp "$(find_first "$FA/fonts/fontawesome-webfont.$face")" \
+     "$OUT/vendor/font-awesome/fonts/"
+done
 say "visualizer deps (cytoscape + 4 plugins, jquery, bootstrap, require-css, q, mustache, highlight)"
 
 # 4. example models -- the same fixtures the test suite generates from,

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -168,24 +168,60 @@ function firstExisting(candidates) {
 
 // ---- 3. every copied source matches the original ------------------
 // The playground must run the SAME code as WebGME and the CLI, so
-// nothing may be edited on its way into the build.
-['src/common', 'src/common/viz',
- 'src/visualizers/widgets/HFSMViz',
- 'src/visualizers/widgets/HFSMViz/Simulator',
- 'src/visualizers/widgets/HFSMViz/Dialog',
-].forEach(function (dir) {
+// nothing may be edited on its way into the build -- and nothing may
+// go MISSING either. The widget loads its markup through `text!` and
+// its styles through `css!`, so a lost .html or .css breaks the
+// Diagram tab exactly as a lost .js would, and a check that skipped
+// them (or that treated "not copied" as "fine") would pass over it.
+//
+// Hence: compare the whole copied tree, and name the only two files
+// allowed to be absent.
+var NOT_SHIPPED = [
+  // WebGME-only adapters; their absence is asserted above
+  'src/visualizers/widgets/HFSMViz/WebGMEBackend.js',
+  'src/visualizers/widgets/HFSMViz/WebGMEHost.js',
+];
+
+function relPath(full) {
+  return path.relative(repoRoot, full).split(path.sep).join('/');
+}
+
+/** every file under `dir`, recursively, compared byte for byte */
+function verifyCopiedTree(dir) {
+  walkFiles(path.join(repoRoot, dir), function (source) {
+    verifyCopied(source);
+  });
+}
+
+/** just the .js directly in `dir` -- what build-web.sh copies there */
+function verifyCopiedModules(dir) {
   fs.readdirSync(path.join(repoRoot, dir))
     .filter(function (f) { return f.slice(-3) === '.js'; })
     .forEach(function (f) {
-      var shipped = path.join(dist, dir, f);
-      // the WebGME adapters are deliberately not shipped
-      if (!fs.existsSync(shipped)) return;
-      var a = fs.readFileSync(path.join(repoRoot, dir, f), 'utf8');
-      if (a !== fs.readFileSync(shipped, 'utf8')) {
-        fail(dir + '/' + f + ' differs from the build copy');
-      }
+      verifyCopied(path.join(repoRoot, dir, f));
     });
-});
+}
+
+function verifyCopied(source) {
+  var rel = relPath(source);
+  if (NOT_SHIPPED.indexOf(rel) > -1) return;
+  var shipped = path.join(dist, rel);
+  if (!fs.existsSync(shipped)) {
+    fail(rel + ' was not copied into the build -- the playground ' +
+         'cannot load what is not there');
+  }
+  if (fs.readFileSync(source).compare(fs.readFileSync(shipped)) !== 0) {
+    fail(rel + ' differs from the build copy');
+  }
+}
+
+// the generator: build-web.sh copies the .js in these two directories
+// (src/common also holds meta.json, a build input the page never
+// loads, and a Templates/ tree the playground does not use)
+verifyCopiedModules('src/common');
+verifyCopiedModules('src/common/viz');
+// the visualizer: copied wholesale, so compared wholesale
+verifyCopiedTree('src/visualizers/widgets/HFSMViz');
 
 // ---- 4. same output as the CLI / goldens --------------------------
 var requirejs = require('requirejs');

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -53,7 +53,51 @@ function must(file) {
  'src/plugins/SoftwareGenerator/templates/MetaTemplates.js',
  'src/plugins/SoftwareGenerator/templates/uml/Templates.js',
  'src/plugins/SoftwareGenerator/templates/uml/static/magic_enum.hpp',
+ // the visualizer and the contracts it runs on
+ 'viz.js',
+ 'src/common/viz/ModelBackend.js', 'src/common/viz/HostServices.js',
+ 'src/common/viz/LocalBackend.js', 'src/common/viz/describe.js',
+ 'src/visualizers/widgets/HFSMViz/HFSMVizWidget.js',
+ 'src/visualizers/widgets/HFSMViz/Simulator/Simulator.js',
+ 'src/decorators/UMLStateMachineDecorator/DiagramDesigner/UMLStateMachineDecorator.DiagramDesignerWidget.css',
+ 'vendor/jquery.min.js', 'vendor/bootstrap.min.js', 'vendor/css.min.js',
+ 'vendor/q.js',
+ 'vendor/bower/cytoscape/dist/cytoscape.min.js',
+ 'vendor/bower/cytoscape-cose-bilkent/cytoscape-cose-bilkent.js',
+ 'vendor/bower/cytoscape-edgehandles/cytoscape-edgehandles.js',
+ 'vendor/bower/cytoscape-context-menus/cytoscape-context-menus.js',
+ 'vendor/bower/cytoscape-panzoom/cytoscape-panzoom.js',
+ 'vendor/bower/mustache.js/mustache.min.js',
 ].forEach(must);
+
+// The WebGME adapters must NOT ship: nothing here can load them, and
+// their absence is what makes "the playground contains no WebGME"
+// checkable rather than merely intended.
+['src/visualizers/widgets/HFSMViz/WebGMEBackend.js',
+ 'src/visualizers/widgets/HFSMViz/WebGMEHost.js',
+].forEach(function (rel) {
+  if (fs.existsSync(path.join(dist, rel))) {
+    fail(rel + ' was shipped; it is WebGME-only and nothing can load it here');
+  }
+});
+
+// ... and nothing that DID ship may reach for a WebGME module
+walkFiles(path.join(dist, 'src'), function (file) {
+  if (file.slice(-3) !== '.js') return;
+  var text = fs.readFileSync(file, 'utf8');
+  var hit = text.match(/['"](js\/[^'"]*|client\/[^'"]*)['"]|\bWebGMEGlobal\b/);
+  if (hit) {
+    fail(path.relative(dist, file) + ' references WebGME-only ' + hit[0]);
+  }
+});
+
+function walkFiles(dir, fn) {
+  fs.readdirSync(dir).forEach(function (entry) {
+    var full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) walkFiles(full, fn);
+    else fn(full);
+  });
+}
 
 // ---- 2. self-contained -------------------------------------------
 var html = fs.readFileSync(path.join(dist, 'index.html'), 'utf8');
@@ -122,14 +166,26 @@ function firstExisting(candidates) {
   }
 });
 
-// ---- 3. the copied generator matches the source -------------------
-fs.readdirSync(path.join(repoRoot, 'src', 'common'))
-  .filter(function (f) { return f.slice(-3) === '.js'; })
-  .forEach(function (f) {
-    var a = fs.readFileSync(path.join(repoRoot, 'src', 'common', f), 'utf8');
-    var b = fs.readFileSync(path.join(dist, 'src', 'common', f), 'utf8');
-    if (a !== b) fail('src/common/' + f + ' differs from the build copy');
-  });
+// ---- 3. every copied source matches the original ------------------
+// The playground must run the SAME code as WebGME and the CLI, so
+// nothing may be edited on its way into the build.
+['src/common', 'src/common/viz',
+ 'src/visualizers/widgets/HFSMViz',
+ 'src/visualizers/widgets/HFSMViz/Simulator',
+ 'src/visualizers/widgets/HFSMViz/Dialog',
+].forEach(function (dir) {
+  fs.readdirSync(path.join(repoRoot, dir))
+    .filter(function (f) { return f.slice(-3) === '.js'; })
+    .forEach(function (f) {
+      var shipped = path.join(dist, dir, f);
+      // the WebGME adapters are deliberately not shipped
+      if (!fs.existsSync(shipped)) return;
+      var a = fs.readFileSync(path.join(repoRoot, dir, f), 'utf8');
+      if (a !== fs.readFileSync(shipped, 'utf8')) {
+        fail(dir + '/' + f + ' differs from the build copy');
+      }
+    });
+});
 
 // ---- 4. same output as the CLI / goldens --------------------------
 var requirejs = require('requirejs');

--- a/src/common/exportModel.js
+++ b/src/common/exportModel.js
@@ -1,0 +1,113 @@
+/**
+ * Serialize a model to the portable JSON the CLI, the playground and
+ * the checker all read -- the inverse of resolveModel.
+ *
+ * WHY POSITIONS MATTER HERE
+ * -------------------------
+ * Laying a state machine out by hand is real work: which state sits
+ * where, and next to what, is most of what makes a diagram readable.
+ * If the exported model does not carry that, the layout is thrown
+ * away every time the model leaves WebGME, and the same model draws
+ * differently in the editor and in the playground. So `position` is
+ * part of the format, not an editor detail.
+ *
+ * WHAT IS DROPPED
+ * ---------------
+ * Everything derivable: `childPaths` (containment is the path),
+ * `path` (it is the key), the flattened attribute copies, and
+ * attributes still at their metamodel default. What is left is what a
+ * person would have written by hand, which is also what makes the
+ * result reviewable in a diff.
+ */
+define(['./metaRules'], function (metaRules) {
+  'use strict';
+
+  var TYPES = metaRules.types;
+
+  function isDefault(type, attr, value) {
+    var meta = TYPES[type] && TYPES[type].attributes[attr];
+    return !!meta && meta.default !== undefined && meta.default === value;
+  }
+
+  function positionOf(obj) {
+    var pos = obj.position;
+    if (!pos || typeof pos.x !== 'number' || typeof pos.y !== 'number') {
+      return null;
+    }
+    // whole pixels: the diagram is not sensitive to sub-pixel offsets
+    // and rounding keeps the diffs readable
+    return { x: Math.round(pos.x), y: Math.round(pos.y) };
+  }
+
+  return {
+    /**
+     * @param model  { root, objects } -- objects may be raw
+     *   webgme-to-json output or an already-resolved model
+     * @param opts   { namespace }
+     * @return a plain object ready for JSON.stringify
+     */
+    toPortable: function (model, opts) {
+      opts = opts || {};
+      var objects = model.objects || {};
+      var out = {};
+
+      Object.keys(objects).sort().forEach(function (path) {
+        var obj = objects[path];
+        if (!obj || !obj.type) return;
+
+        var entry = { name: obj.name, type: obj.type };
+
+        var position = positionOf(obj);
+        if (position) entry.position = position;
+
+        // Attributes come from the METAMODEL's list for this type,
+        // not from whatever keys the object happens to have. By the
+        // time a model has been through resolveModel and the
+        // processor it also carries derived fields -- Substates,
+        // *_list arrays, sanitizedName -- and asking the metamodel is
+        // what keeps those out without having to enumerate them.
+        //
+        // Values are read off the object itself: resolveModel
+        // flattens `attributes` onto it, and a hand-authored model
+        // writes them there directly, so the object is the one place
+        // both agree on.
+        var declared = (TYPES[obj.type] && TYPES[obj.type].attributes) || {};
+        Object.keys(declared).sort().forEach(function (attr) {
+          if (attr === 'name') return;   // already written above
+          var value = obj[attr];
+          if (value === undefined && obj.attributes) {
+            value = obj.attributes[attr];
+          }
+          if (value === undefined || value === null) return;
+          if (typeof value === 'object' || typeof value === 'function') return;
+          if (isDefault(obj.type, attr, value)) return;
+          entry[attr] = value;
+        });
+
+        var pointers = obj.pointers || {};
+        var kept = {};
+        Object.keys(pointers).sort().forEach(function (name) {
+          if (pointers[name]) kept[name] = pointers[name];
+        });
+        if (Object.keys(kept).length) entry.pointers = kept;
+
+        out[path] = entry;
+      });
+
+      var portable = {
+        root: typeof model.root === 'string'
+          ? model.root
+          : (model.root && model.root.path),
+        objects: out,
+      };
+      var namespace = opts.namespace || model.namespace;
+      if (namespace) portable.namespace = namespace;
+      return portable;
+    },
+
+    /** the same thing, as the text that gets written to a file */
+    toJSON: function (model, opts) {
+      return JSON.stringify(this.toPortable(model, opts), null, 2) + '\n';
+    },
+  };
+});

--- a/src/common/exportModel.js
+++ b/src/common/exportModel.js
@@ -51,7 +51,12 @@ define(['./metaRules'], function (metaRules) {
       var objects = model.objects || {};
       var out = {};
 
-      Object.keys(objects).sort().forEach(function (path) {
+      // The model's own object order is kept, NOT sorted. Sibling
+      // order is what the generator declares states in, so sorting
+      // here would quietly rewrite the output of every model whose
+      // author did not happen to name things alphabetically -- an
+      // export that changes the generated code is not a round trip.
+      Object.keys(objects).forEach(function (path) {
         var obj = objects[path];
         if (!obj || !obj.type) return;
 

--- a/src/common/resolveModel.js
+++ b/src/common/resolveModel.js
@@ -12,7 +12,14 @@
  *     parentPath: '/root',
  *     attributes: { ... },          // optional; flattened onto the object
  *     pointers:   { src: '/x', dst: '/y' },   // transitions only
+ *     position:   { x: 120, y: 40 },          // optional; see below
  *   }
+ *
+ * POSITION is part of the format, not an editor detail. Laying a
+ * machine out by hand is real work, and a model that does not carry
+ * it loses that layout every time it leaves the editor -- and draws
+ * differently in the editor and in the playground. Models without
+ * positions still load; the viewer arranges them automatically.
  *
  * The resolver:
  *   - flattens `attributes` onto the object (like webgme-to-json does)
@@ -133,6 +140,18 @@ define(['./metaRules'], function(metaRules) {
         });
         if (!obj.pointers) {
           obj.pointers = {};
+        }
+        // a malformed position would otherwise reach the diagram as
+        // NaN, which cytoscape renders as a node in an arbitrary spot
+        // rather than an error anyone can act on
+        if (obj.position !== undefined) {
+          var pos = obj.position;
+          if (!pos || typeof pos !== 'object' ||
+              typeof pos.x !== 'number' || !isFinite(pos.x) ||
+              typeof pos.y !== 'number' || !isFinite(pos.y)) {
+            throw "ERROR: " + path + " has an invalid position; expected " +
+              "{ x: <number>, y: <number> }.";
+          }
         }
         var idx = obj.path.lastIndexOf('/');
         var lexicalParent = idx > 0 ? obj.path.substring(0, idx) : '';

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -1,0 +1,51 @@
+/**
+ * The last step of turning a model node into the descriptor the
+ * visualizer draws.
+ *
+ * A ModelBackend reports what a node IS; this adds what the graph
+ * needs to DISPLAY it -- the edge/label text, and the fact that a
+ * machine at the top has no parent to nest inside. Both hosts finish
+ * their descriptors here so the two graphs read identically: a
+ * transition labelled `EVENT [guard]` in WebGME is labelled the same
+ * in the playground, without either side keeping its own copy of the
+ * rule.
+ */
+define([], function () {
+  'use strict';
+
+  // a machine or a library is the top of a diagram; nothing draws
+  // around it, so it must not report a parent to nest inside
+  var ROOT_TYPES = ['State Machine', 'Library'];
+
+  function isTransition(desc) {
+    return desc.isConnection || desc.type === 'Internal Transition';
+  }
+
+  return {
+    ROOT_TYPES: ROOT_TYPES,
+
+    /**
+     * @param desc  a descriptor from a ModelBackend, or null
+     * @return the same object, finished (mutated in place, as the
+     *         callers already own it)
+     */
+    finish: function (desc) {
+      if (!desc) return desc;
+
+      // a transition shows its trigger, not its name
+      if (isTransition(desc)) {
+        desc.LABEL = desc.Event;
+        if (desc.Guard) {
+          desc.LABEL += ' [' + desc.Guard + ']';
+        }
+      } else {
+        desc.LABEL = desc.name;
+      }
+
+      if (ROOT_TYPES.indexOf(desc.type) > -1) {
+        desc.parentId = null;
+      }
+      return desc;
+    },
+  };
+});

--- a/src/common/viz/layoutInput.js
+++ b/src/common/viz/layoutInput.js
@@ -1,0 +1,58 @@
+/**
+ * Which parts of the graph an automatic layout should be run over.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A local transition goes from a state to one of its OWN substates,
+ * and drawn as a compound graph that is an edge between a node and its
+ * own descendant. cose-bilkent calls such an edge invalid
+ * (`LGraphManager.includesInvalidEdge`) and, on finding one, abandons
+ * the whole layout -- silently, with no error and no thrown exception:
+ * `checkLayoutSuccess()` short-circuits, every node keeps the position
+ * it already had, and `layoutstop` still fires as if it had worked.
+ * One local transition anywhere in a machine is enough to make the
+ * auto-layout button do nothing at all.
+ *
+ * Leaving those edges out of the layout INPUT fixes it, and costs
+ * nothing: an edge to your own descendant carries no positional
+ * information anyway -- containment already says where the child goes.
+ * The edge is still in the graph and still drawn; it just does not
+ * pull.
+ *
+ * This is kept out of the widget, and free of cytoscape, so it can be
+ * tested without a browser.
+ */
+define([], function () {
+  'use strict';
+
+  /**
+   * @param graph  { nodes: [{ id, parent }], edges: [{ id, source, target }] }
+   * @return the ids of the edges to leave out, in input order
+   */
+  function excludedEdges(graph) {
+    var parentOf = {};
+    (graph.nodes || []).forEach(function (node) {
+      parentOf[node.id] = node.parent || null;
+    });
+
+    function isAncestorOf(maybeAncestor, id) {
+      var at = parentOf[id];
+      while (at) {
+        if (at === maybeAncestor) return true;
+        at = parentOf[at];
+      }
+      return false;
+    }
+
+    return (graph.edges || []).filter(function (edge) {
+      return isAncestorOf(edge.source, edge.target) ||
+             isAncestorOf(edge.target, edge.source);
+    }).map(function (edge) {
+      return edge.id;
+    });
+  }
+
+  return {
+    excludedEdges: excludedEdges,
+  };
+});

--- a/src/plugins/SoftwareGenerator/SoftwareGenerator.js
+++ b/src/plugins/SoftwareGenerator/SoftwareGenerator.js
@@ -15,6 +15,7 @@ define([
   './templates/MetaTemplates',
   'webgme-to-json/webgme-to-json',
   'hfsm/processor',
+  'hfsm/exportModel',
   'q'
 ], function (
   PluginConfig,
@@ -23,6 +24,7 @@ define([
   MetaTemplates,
   webgmeToJson,
   processor,
+  exportModel,
   Q) {
   'use strict';
 
@@ -126,6 +128,24 @@ define([
 
     webgmeToJson.loadModel(self.core, self.rootNode, projectNode, true, true)
       .then(function (projectModel) {
+        // webgme-to-json reports attributes and pointers but not the
+        // REGISTRY, which is where WebGME keeps the layout. Without
+        // this the exported model has no positions, and the diagram
+        // has to be re-arranged by hand every time it is opened
+        // anywhere else. loadModel was asked to keep the nodes, so
+        // the registry is right here.
+        Object.keys(projectModel.objects || {}).forEach(function (path) {
+          var obj = projectModel.objects[path];
+          if (!obj || !obj.node) return;
+          var position = self.core.getRegistry(obj.node, 'position');
+          if (position &&
+              typeof position.x === 'number' && typeof position.y === 'number') {
+            obj.position = { x: position.x, y: position.y };
+          }
+        });
+        return projectModel;
+      })
+      .then(function (projectModel) {
         // make convenience members and extra data; pass through the
         // commit hash / branch name provided by PluginBase so the
         // generated metadata records where the code came from.
@@ -184,6 +204,12 @@ define([
         pluginVersion: self.getVersion()
       }, null, 2);
     }
+
+    // The model itself, in the portable form the CLI and the
+    // playground read -- layout included. This is what makes a model
+    // laid out here open the same way anywhere else.
+    artifacts[self.projectRoot.sanitizedName + '_model.json'] =
+      exportModel.toJSON(self.projectModel, { namespace: self.namespace });
 
     var hfsmArtifacts = MetaTemplates.renderHFSM( self.projectModel, self.namespace, objToFilePrefixFn );
     artifacts = Object.assign(artifacts, hfsmArtifacts);

--- a/src/visualizers/panels/HFSMViz/HFSMVizControl.js
+++ b/src/visualizers/panels/HFSMViz/HFSMVizControl.js
@@ -7,11 +7,13 @@
 define([
     'js/Constants',
     'js/Utils/GMEConcepts',
-    'js/NodePropertyNames'
+    'js/NodePropertyNames',
+    'hfsm/viz/describe'
 ], function (
     CONSTANTS,
     GMEConcepts,
-    nodePropertyNames
+    nodePropertyNames,
+    describe
 ) {
 
     'use strict';
@@ -110,25 +112,15 @@ define([
 		node.getAttributeNames().map(function(a) {
 		    objDescriptor[a] = node.getAttribute(a);
 		});
-		objDescriptor.LABEL = objDescriptor.name;
-		// add the node pointers if it's a connection
+		// endpoints first: the label rules below depend on
+		// knowing this is a connection
 		if (objDescriptor.isConnection) {
 		    objDescriptor.src = node.getPointer('src').to;
 		    objDescriptor.dst = node.getPointer('dst').to;
-		    objDescriptor.LABEL = objDescriptor.Event;
-		    if (objDescriptor.Guard) {
-			objDescriptor.LABEL += ' [' + objDescriptor.Guard + ']';
-		    }
 		}
-		else if (objDescriptor.type == 'Internal Transition') {
-		    objDescriptor.LABEL = objDescriptor.Event;
-		    if (objDescriptor.Guard) {
-			objDescriptor.LABEL += ' [' + objDescriptor.Guard + ']';
-		    }
-		}
-		// make sure the root level has no parentId
-		if (rootTypes.indexOf(objDescriptor.type) > -1)
-		    objDescriptor.parentId = null;
+		// labels and the root's missing parent are display rules,
+		// shared with the playground so the two graphs read alike
+		describe.finish(objDescriptor);
 	    }
         }
 

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -1314,10 +1314,31 @@ define([
       });
     };
 
-    HFSMVizWidget.prototype.reLayout = function() {
+    /**
+     * @param overrides  optional cytoscape layout options. A host
+     *   whose models carry no saved positions needs a different
+     *   layout from the one the toolbar's Auto-Arrange offers, so it
+     *   can ask for one rather than reach into _cy.
+     */
+    HFSMVizWidget.prototype.reLayout = function( overrides ) {
       var self = this;
-      var layout = self._cy.layout(self._layout_options);
+      var options = overrides
+        ? _.extend({}, self._layout_options, overrides)
+        : self._layout_options;
+      var layout = self._cy.layout(options);
       layout.run();
+    };
+
+    /**
+     * Drop the simulator's log. Loading a model feeds it one node at
+     * a time, and the checks it runs on the way report on a model
+     * that is still half-built -- true at the moment, but noise by
+     * the time it is all there.
+     */
+    HFSMVizWidget.prototype.clearSimulationLog = function() {
+      if (this._simulator && this._simulator.clearLogs) {
+        this._simulator.clearLogs();
+      }
     };
 
     HFSMVizWidget.prototype.getDescData = function(desc) {

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -10,6 +10,7 @@ define([
   "text!./HFSM.html",
   "./Dialog/Dialog",
   "hfsm/viz/HostServices",
+  "hfsm/viz/layoutInput",
   "./Simulator/Simulator",
   "./Simulator/Choice",
   // built-ins
@@ -35,6 +36,7 @@ define([
     HFSMHtml,
     Dialog,
     HostServices,
+    layoutInput,
     Simulator,
     Choice,
     // built-ins
@@ -1093,18 +1095,29 @@ define([
       });
 
       toolbarEl.find('#layout').on('click', function(){
-        // ask if they really want to randomize the layout
+        // Offer every layout this cytoscape actually has, rather than
+        // one hardcoded name: which one reads best depends on the
+        // machine, and the only way to find out is to try them.
+        var available = self.availableLayouts();
+        var choices = available.map(function(name) {
+          return name === self._layout_options.name
+            ? "Run the " + name + " layout (current)"
+            : "Run the " + name + " layout";
+        });
+        choices.push("No, do not change any positions");
+
         var choice = new Choice();
-        var choices = [
-          "Yes, run the " + self._layout_options.name + " layout.",
-          "No, do not change any positions"
-        ];
-        choice.initialize( choices, "Really change the layout?" );
+        choice.initialize( choices, "Re-arrange the diagram with which layout?" );
         choice.show();
         return choice.waitForChoice()
-          .then(function(choice) {
-            if (choice == choices[0])
-              self.reLayout();
+          .then(function(picked) {
+            var index = choices.indexOf(picked);
+            if (index < 0 || index >= available.length)
+              return;   // cancelled, or the "do not change" entry
+            // remember it, so the next automatic arrangement and the
+            // "(current)" marker both follow what was chosen
+            self.setLayoutOptions({ name: available[index] });
+            self.reLayout();
           });
       });
     };
@@ -1338,17 +1351,62 @@ define([
      * needs a different one from WebGME's, so it can say so once
      * rather than passing overrides at every call site.
      */
+    // Layouts worth offering: cytoscape's own, plus the extension the
+    // app registers. Whether each is really there is asked of
+    // cytoscape rather than assumed -- an extension that failed to
+    // register should not be offered.
+    var CANDIDATE_LAYOUTS = ['breadthfirst', 'cose', 'cose-bilkent',
+                             'circle', 'concentric', 'grid', 'random'];
+
+    HFSMVizWidget.prototype.availableLayouts = function() {
+      return CANDIDATE_LAYOUTS.filter(function(name) {
+        return typeof cytoscape('layout', name) === 'function';
+      });
+    };
+
     HFSMVizWidget.prototype.setLayoutOptions = function( overrides ) {
       this._layout_options = _.extend({}, this._layout_options, overrides || {});
     };
 
     HFSMVizWidget.prototype.reLayout = function( overrides ) {
       var self = this;
-      var options = overrides
-        ? _.extend({}, self._layout_options, overrides)
-        : self._layout_options;
+      var options = _.extend({}, self._layout_options, overrides || {},
+                             { eles: self._layoutElements() });
       var layout = self._cy.layout(options);
       layout.run();
+    };
+
+    /**
+     * The graph to lay out: everything, minus the edges a layout
+     * cannot cope with.
+     *
+     * A local transition is an edge from a state into its own
+     * substate, and cose-bilkent quietly abandons an entire layout on
+     * finding one -- no error, no exception, `layoutstop` still fires,
+     * and every node keeps the position it already had. Since such an
+     * edge says nothing about where anything should go (containment
+     * already places the child), dropping it from the INPUT loses
+     * nothing and gets the layout to run. The edge is still drawn.
+     */
+    HFSMVizWidget.prototype._layoutElements = function() {
+      var self = this;
+      var excluded = layoutInput.excludedEdges({
+        nodes: self._cy.nodes().map(function(node) {
+          var parent = node.parent();
+          return { id: node.id(),
+                   parent: parent && parent.length ? parent.id() : null };
+        }),
+        edges: self._cy.edges().map(function(edge) {
+          return { id: edge.id(),
+                   source: edge.source().id(),
+                   target: edge.target().id() };
+        }),
+      });
+      if (!excluded.length)
+        return self._cy.elements();
+      return self._cy.elements().filter(function(ele) {
+        return excluded.indexOf(ele.id()) < 0;
+      });
     };
 
     /**

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -142,24 +142,32 @@ define([
       return windowPos;
     };
 
+    /**
+     * A page coordinate, expressed relative to this widget's own
+     * container.
+     *
+     * This used to subtract the offsets of two WebGME panels
+     * (`.panel-base-wh`, `.ui-layout-pane-center`). Those selectors
+     * match nothing in another host, so `.position()` came back
+     * undefined and reading `.left` off it threw -- silently killing
+     * the mousemove handler, which is why the splitter could be seen
+     * but not dragged outside WebGME.
+     *
+     * The container's own bounding box says the same thing without
+     * naming anyone else's DOM.
+     */
     HFSMVizWidget.prototype._getContainerPosFromEvent = function( e ) {
       var self = this;
-      var x = e.pageX || e.position.x,
-          y = e.pageY || e.position.y;
-      var selector = $(self._el).find(self._containerTag);
-      var splitPos = $(self._container).parents(".panel-base-wh").parent().position();
-      var centerPanelPos = $(".ui-layout-pane-center").position();
-      // X OFFSET
-      x -= splitPos.left;
-      x -= centerPanelPos.left;
-
-      // Y OFFSET
-      y -= splitPos.top;
-      y -= centerPanelPos.top;
-
+      var x = e.pageX !== undefined ? e.pageX : e.position.x;
+      var y = e.pageY !== undefined ? e.pageY : e.position.y;
+      var node = self._container && self._container[0];
+      if (!node) {
+        return { x: x, y: y };
+      }
+      var rect = node.getBoundingClientRect();
       return {
-        x: x,
-        y: y
+        x: x - (rect.left + window.pageXOffset),
+        y: y - (rect.top + window.pageYOffset),
       };
     };
 
@@ -518,7 +526,10 @@ define([
       });
 
       var edgeHandleIcon = new Image(10,10);
-      edgeHandleIcon.src = "/assets/DecoratorSVG/svgs/edgeIcon.svg";
+      // relative, like the other decorator SVGs: an absolute path
+      // assumes the app is served from the domain root, which is true
+      // in WebGME and false for a project page under /<repo>/
+      edgeHandleIcon.src = "assets/DecoratorSVG/svgs/edgeIcon.svg";
 
       // the default values of each option are outlined below:
       var edgeHandleDefaults = {

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -1096,7 +1096,7 @@ define([
         // ask if they really want to randomize the layout
         var choice = new Choice();
         var choices = [
-          "Yes, run cose-bilkent layout.",
+          "Yes, run the " + self._layout_options.name + " layout.",
           "No, do not change any positions"
         ];
         choice.initialize( choices, "Really change the layout?" );
@@ -1331,6 +1331,17 @@ define([
      *   layout from the one the toolbar's Auto-Arrange offers, so it
      *   can ask for one rather than reach into _cy.
      */
+    /**
+     * Change the layout this widget uses by default -- both the
+     * toolbar's button and any host that asks for an automatic
+     * arrangement. A host whose models carry no saved positions
+     * needs a different one from WebGME's, so it can say so once
+     * rather than passing overrides at every call site.
+     */
+    HFSMVizWidget.prototype.setLayoutOptions = function( overrides ) {
+      this._layout_options = _.extend({}, this._layout_options, overrides || {});
+    };
+
     HFSMVizWidget.prototype.reLayout = function( overrides ) {
       var self = this;
       var options = overrides

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
@@ -160,16 +160,18 @@ define(['q',
              self.isDragging = false;
            }).mousemove(function(e) {
              if (self.isDragging) {
-               var selector = $(self._container).parent();
-               var mousePosY = e.pageY;
-
-               // convert Y position as needed
-               // get offset from split panel
-               var splitOffset = $(self._container).parents('.panel-base-wh').parent().position().top;
-               mousePosY -= splitOffset;
-               // get offset from top panel
-               var northOffset = $('.ui-layout-pane-center').position().top;
-               mousePosY -= northOffset;
+               // Measure against this panel's own box. The old code
+               // subtracted the offsets of two WebGME panels, whose
+               // selectors match nothing anywhere else -- .position()
+               // then returned undefined and reading .top off it threw,
+               // killing this handler and with it the drag.
+               var selector = self._el;
+               var box = self._el[0].getBoundingClientRect();
+               // the panel scrolls, so the point has to be in CONTENT
+               // coordinates -- the panels are sized as a percentage
+               // of it, not of what happens to be on screen
+               var mousePosY = e.pageY - (box.top + window.pageYOffset) +
+                   self._el[0].scrollTop;
 
                var maxHeight = selector.height();
                var handlePercent = 0.5;

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
@@ -3,6 +3,7 @@
  */
 
 define(['q',
+        'underscore',
         './Choice',
         './FormDialog',
         'hfsm/declParser',
@@ -14,6 +15,7 @@ define(['q',
         'css!bower/highlightjs/styles/default.css',
         'css!./Simulator.css'],
        function(Q,
+                _,
                 Choice,
                 FormDialog,
                 declParser,

--- a/test/exportModel.spec.js
+++ b/test/exportModel.spec.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Exporting a model has one job: what comes back in must be the same
+ * machine that went out, layout included.
+ *
+ * The layout part is the reason this exists. Arranging a state chart
+ * so it reads well is real work, and a format that drops it makes
+ * that work disposable -- and makes the same model draw differently
+ * in the editor and in the playground.
+ */
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var amdLoader = require('../bin/amd-loader');
+
+var mods = {};
+var repoRoot = path.resolve(__dirname, '..');
+
+function fixture(name) {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'test/fixtures', name + '.json'), 'utf8'));
+}
+
+describe('exportModel', function() {
+
+  before(function() {
+    return amdLoader.load([
+      'src/common/exportModel',
+      'src/common/resolveModel',
+      'src/common/processor',
+      'src/common/meta',
+    ]).then(function(loaded) {
+      mods.exportModel = loaded[0];
+      mods.resolveModel = loaded[1];
+      mods.processor = loaded[2];
+      mods.meta = loaded[3];
+    });
+  });
+
+  it('keeps positions, rounded to whole pixels', function() {
+    var model = fixture('basic');
+    model.objects['/p/m/Idle'].position = { x: 120.4, y: 40.6 };
+    mods.resolveModel.resolve(model);
+
+    var out = mods.exportModel.toPortable(model);
+    assert.deepStrictEqual(out.objects['/p/m/Idle'].position, { x: 120, y: 41 });
+  });
+
+  it('omits a position rather than inventing one', function() {
+    var model = fixture('basic');
+    mods.resolveModel.resolve(model);
+    var out = mods.exportModel.toPortable(model);
+    assert.ok(!('position' in out.objects['/p/m/Idle']),
+              'a model without a layout should not gain a made-up one');
+  });
+
+  it('keeps attributes the author set, wherever they wrote them', function() {
+    // basic.json writes attributes at the top level; webgme-to-json
+    // nests them under `attributes`. Both must survive.
+    var model = fixture('basic');
+    mods.resolveModel.resolve(model);
+    var out = mods.exportModel.toPortable(model);
+    assert.strictEqual(out.objects['/p/m'].Includes, '#include <cstdio>');
+    assert.strictEqual(out.objects['/p/m'].Declarations, 'int startCount = 0;');
+
+    var nested = fixture('basic');
+    var idle = nested.objects['/p/m/Idle'];
+    nested.objects['/p/m/Idle'] = {
+      name: idle.name, type: idle.type,
+      attributes: { Entry: idle.Entry, 'Timer Period': idle['Timer Period'] },
+    };
+    mods.resolveModel.resolve(nested);
+    var out2 = mods.exportModel.toPortable(nested);
+    assert.strictEqual(out2.objects['/p/m/Idle'].Entry, idle.Entry);
+  });
+
+  it('drops attributes still at their metamodel default', function() {
+    var model = fixture('basic');
+    mods.resolveModel.resolve(model);   // fills in every default
+    var out = mods.exportModel.toPortable(model);
+    // Enabled defaults to true, so a plain transition should not
+    // carry it; otherwise every export grows every default
+    assert.ok(!('Enabled' in out.objects['/p/m/tStart']),
+              'a default-valued attribute should not be written out');
+    assert.strictEqual(mods.meta.types['External Transition']
+                       .attributes.Enabled.default, true);
+  });
+
+  it('drops derived fields the processor adds', function() {
+    var model = fixture('features');
+    mods.resolveModel.resolve(model);
+    mods.processor.processModel(model);   // adds Substates, *_list, ...
+    var out = mods.exportModel.toPortable(model);
+    Object.keys(out.objects).forEach(function(p) {
+      Object.keys(out.objects[p]).forEach(function(key) {
+        assert.ok(!/(_list|Substates|sanitizedName|LABEL|childPaths|parentPath)/.test(key),
+                  p + ' exported a derived field: ' + key);
+      });
+    });
+  });
+
+  it('round-trips: the export generates the same code as the original',
+     function() {
+       // the guarantee that matters -- a model can go out and come
+       // back without becoming a different machine
+       ['basic', 'features', 'payloads'].forEach(function(name) {
+         var original = fixture(name);
+         mods.resolveModel.resolve(original);
+         mods.processor.processModel(original);
+
+         var exported = fixture(name);
+         mods.resolveModel.resolve(exported);
+         var text = mods.exportModel.toJSON(exported);
+         var reimported = JSON.parse(text);
+         mods.resolveModel.resolve(reimported);
+         mods.processor.processModel(reimported);
+
+         // compare what the templates actually consume
+         assert.deepStrictEqual(
+           Object.keys(reimported.objects).sort(),
+           Object.keys(original.objects).sort(),
+           name + ': the object set changed');
+         Object.keys(original.objects).forEach(function(p) {
+           var a = original.objects[p], b = reimported.objects[p];
+           assert.strictEqual(b.type, a.type, name + ' ' + p + ': type');
+           assert.strictEqual(b.name, a.name, name + ' ' + p + ': name');
+           assert.deepStrictEqual(b.pointers, a.pointers,
+                                  name + ' ' + p + ': pointers');
+         });
+       });
+     });
+
+  it('survives a second export unchanged', function() {
+    // exporting an export must be a no-op, or every save would churn
+    var model = fixture('features');
+    mods.resolveModel.resolve(model);
+    var once = mods.exportModel.toJSON(model);
+
+    var again = JSON.parse(once);
+    mods.resolveModel.resolve(again);
+    assert.strictEqual(mods.exportModel.toJSON(again), once,
+                       'a second export should be byte-identical');
+  });
+});

--- a/test/exportModel.spec.js
+++ b/test/exportModel.spec.js
@@ -25,19 +25,43 @@ function fixture(name) {
 
 describe('exportModel', function() {
 
+  var NAMESPACE = 'state_machine';
+
   before(function() {
     return amdLoader.load([
       'src/common/exportModel',
       'src/common/resolveModel',
       'src/common/processor',
       'src/common/meta',
+      'src/common/exporters',
+      'src/plugins/SoftwareGenerator/templates/MetaTemplates',
     ]).then(function(loaded) {
       mods.exportModel = loaded[0];
       mods.resolveModel = loaded[1];
       mods.processor = loaded[2];
       mods.meta = loaded[3];
+      mods.exporters = loaded[4];
+      mods.MetaTemplates = loaded[5];
     });
   });
+
+  /** everything the generator produces for an already-processed model */
+  function generateArtifacts(model) {
+    var artifacts = {};
+    Object.assign(artifacts, mods.MetaTemplates.renderHFSM(model, NAMESPACE));
+    Object.assign(artifacts, mods.MetaTemplates.renderTestCode(model, NAMESPACE));
+    Object.keys(model.objects).sort().forEach(function(p) {
+      var obj = model.objects[p];
+      if (obj.type === 'State Machine' || obj.type === 'Library') {
+        artifacts[obj.sanitizedName + '.mmd'] = mods.exporters.toMermaid(model, p);
+        artifacts[obj.sanitizedName + '.puml'] = mods.exporters.toPlantUML(model, p);
+        artifacts[obj.sanitizedName + '.scxml'] = mods.exporters.toSCXML(model, p);
+      }
+    });
+    // written on every run from the clock, so not comparable
+    delete artifacts['hfsm_metadata.json'];
+    return artifacts;
+  }
 
   it('keeps positions, rounded to whole pixels', function() {
     var model = fixture('basic');
@@ -103,8 +127,13 @@ describe('exportModel', function() {
 
   it('round-trips: the export generates the same code as the original',
      function() {
-       // the guarantee that matters -- a model can go out and come
-       // back without becoming a different machine
+       // The guarantee that matters -- a model can go out and come
+       // back without becoming a different machine. Comparing the
+       // GENERATED ARTIFACTS rather than a chosen handful of fields is
+       // what makes that claim, and only that: an export that dropped
+       // a Guard, an Entry action or an event's payload type would
+       // still line up field by field on ids and names.
+       this.timeout(20000);
        ['basic', 'features', 'payloads'].forEach(function(name) {
          var original = fixture(name);
          mods.resolveModel.resolve(original);
@@ -117,17 +146,16 @@ describe('exportModel', function() {
          mods.resolveModel.resolve(reimported);
          mods.processor.processModel(reimported);
 
-         // compare what the templates actually consume
-         assert.deepStrictEqual(
-           Object.keys(reimported.objects).sort(),
-           Object.keys(original.objects).sort(),
-           name + ': the object set changed');
-         Object.keys(original.objects).forEach(function(p) {
-           var a = original.objects[p], b = reimported.objects[p];
-           assert.strictEqual(b.type, a.type, name + ' ' + p + ': type');
-           assert.strictEqual(b.name, a.name, name + ' ' + p + ': name');
-           assert.deepStrictEqual(b.pointers, a.pointers,
-                                  name + ' ' + p + ': pointers');
+         var before = generateArtifacts(original);
+         var after = generateArtifacts(reimported);
+
+         assert.deepStrictEqual(Object.keys(after).sort(),
+                                Object.keys(before).sort(),
+                                name + ': the generated file set changed');
+         Object.keys(before).forEach(function(file) {
+           assert.strictEqual(after[file], before[file],
+                              name + ': ' + file +
+                              ' generated from the export differs');
          });
        });
      });

--- a/test/layoutInput.spec.js
+++ b/test/layoutInput.spec.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * A local transition -- a state with a transition into its own
+ * substate -- used to make the auto-layout button do nothing at all,
+ * for the WHOLE machine, in both WebGME and the playground.
+ * cose-bilkent classes an edge between a node and its own descendant
+ * as invalid and abandons the layout without an error, so the button
+ * looked like it had worked and nothing had moved.
+ *
+ * Nothing here can catch that end to end -- it takes cytoscape and a
+ * canvas -- but the rule that keeps those edges out of the layout is
+ * plain data, and this pins it down.
+ */
+
+var assert = require('assert');
+var amdLoader = require('../bin/amd-loader');
+
+var layoutInput;
+
+describe('layout input', function() {
+
+  before(function() {
+    return amdLoader.load(['src/common/viz/layoutInput'])
+      .then(function(loaded) { layoutInput = loaded[0]; });
+  });
+
+  it('excludes a transition from a state into its own substate', function() {
+    var excluded = layoutInput.excludedEdges({
+      nodes: [
+        { id: 'A', parent: null },
+        { id: 'A/1', parent: 'A' },
+        { id: 'A/2', parent: 'A' },
+      ],
+      edges: [
+        { id: 'local', source: 'A', target: 'A/2' },
+        { id: 'sibling', source: 'A/1', target: 'A/2' },
+      ],
+    });
+    assert.deepStrictEqual(excluded, ['local']);
+  });
+
+  it('excludes one pointing the other way, out of a substate', function() {
+    var excluded = layoutInput.excludedEdges({
+      nodes: [{ id: 'A', parent: null }, { id: 'A/1', parent: 'A' }],
+      edges: [{ id: 'up', source: 'A/1', target: 'A' }],
+    });
+    assert.deepStrictEqual(excluded, ['up']);
+  });
+
+  it('excludes across more than one level of nesting', function() {
+    // the ancestor need not be the immediate parent
+    var excluded = layoutInput.excludedEdges({
+      nodes: [
+        { id: 'A', parent: null },
+        { id: 'A/B', parent: 'A' },
+        { id: 'A/B/C', parent: 'A/B' },
+      ],
+      edges: [{ id: 'deep', source: 'A', target: 'A/B/C' }],
+    });
+    assert.deepStrictEqual(excluded, ['deep']);
+  });
+
+  it('keeps every edge a layout can actually use', function() {
+    // cousins, siblings and top-level states all inform the layout,
+    // and dropping them would change where things land
+    var excluded = layoutInput.excludedEdges({
+      nodes: [
+        { id: 'A', parent: null },
+        { id: 'B', parent: null },
+        { id: 'A/1', parent: 'A' },
+        { id: 'B/1', parent: 'B' },
+      ],
+      edges: [
+        { id: 'e1', source: 'A', target: 'B' },
+        { id: 'e2', source: 'A/1', target: 'B/1' },
+        { id: 'e3', source: 'A/1', target: 'B' },
+      ],
+    });
+    assert.deepStrictEqual(excluded, []);
+  });
+
+  it('copes with a graph that has nothing in it', function() {
+    assert.deepStrictEqual(layoutInput.excludedEdges({}), []);
+    assert.deepStrictEqual(
+      layoutInput.excludedEdges({ nodes: [], edges: [] }), []);
+  });
+});

--- a/test/simulatorStandalone.spec.js
+++ b/test/simulatorStandalone.spec.js
@@ -147,6 +147,43 @@ describe('simulator outside WebGME', function() {
               Object.keys(seen).length);
   });
 
+  it('imports every library it uses, rather than relying on a global',
+     function() {
+       // The loader tests only prove a module can be CONSTRUCTED. A
+       // library referenced from inside a function -- underscore's
+       // `_`, say -- resolves against the global scope, which WebGME
+       // populates and a plain page does not. That leaves the module
+       // loading cleanly and then throwing the moment the feature is
+       // used: `_ is not defined` is what stopped the simulator's
+       // choice and guard dialogs from ever appearing.
+       var globals = [
+         { name: '_', module: 'underscore', use: /(^|[^a-zA-Z0-9_.'"$])_\./ },
+         { name: '$', module: 'jquery', use: /(^|[^a-zA-Z0-9_.'"])\$\(/ },
+       ];
+       var files = [
+         'src/visualizers/widgets/HFSMViz/HFSMVizWidget.js',
+         'src/visualizers/widgets/HFSMViz/Simulator/Simulator.js',
+         'src/visualizers/widgets/HFSMViz/Simulator/Choice.js',
+         'src/visualizers/widgets/HFSMViz/Simulator/FormDialog.js',
+         'src/visualizers/widgets/HFSMViz/Dialog/Dialog.js',
+       ];
+       files.forEach(function(file) {
+         var text = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+         globals.forEach(function(g) {
+           if (!g.use.test(text)) return;
+           // jQuery is the one exception: every host that can render
+           // this widget has it, and WebGME, the playground and the
+           // dialogs all take it from the page rather than the loader
+           if (g.name === '$') return;
+           var declared = new RegExp("['\"]" + g.module + "['\"]").test(text);
+           assert.ok(declared,
+                     file + ' uses ' + g.name + ' but never asks for ' +
+                     g.module + ', so it only works where a host happens ' +
+                     'to put it on the page');
+         });
+       });
+     });
+
   it('mentions no WebGME module anywhere in its source', function() {
     // Belt and braces. The two tests above only see what they can
     // reach: one loads the modules, the other reads define([...])

--- a/web/app.css
+++ b/web/app.css
@@ -99,6 +99,40 @@ body {
 }
 #viewDiagram #hfsmVizHandle:hover { background: #0969da; }
 
+/* ... and the one inside the simulator, between the event controls
+   and the selected-state view. Same rule: colour only. Those two
+   panels are 49.75% each with a 0.5% handle, so a height here would
+   push the column past 100%. */
+#viewDiagram #simulatorHandle {
+    background: #d0d7de;
+    transition: background .15s;
+}
+#viewDiagram #simulatorHandle:hover { background: #0969da; }
+
+/* The widget's toolbar -- print, zoom to fit, auto-layout. WebGME
+   puts it in the panel header; here it floats over the top-right of
+   the graph, which is the only spare corner. */
+.viz-toolbar {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    z-index: 3;
+    display: flex;
+    gap: 4px;
+    background: rgba(255, 255, 255, .92);
+    border: 1px solid #d0d7de;
+    border-radius: 5px;
+    padding: 4px 6px;
+}
+.viz-toolbar .split-panel-toolbar-btn {
+    cursor: pointer;
+    padding: 3px 6px;
+    border-radius: 4px;
+    color: #57606a;
+    font-size: 14px;
+}
+.viz-toolbar .split-panel-toolbar-btn:hover { background: #eaeef2; color: #0969da; }
+
 .pane {
     display: flex;
     flex-direction: column;

--- a/web/app.css
+++ b/web/app.css
@@ -111,12 +111,18 @@ body {
 
 /* The widget's toolbar -- print, zoom to fit, auto-layout. WebGME
    puts it in the panel header; here it floats over the top-right of
-   the graph, which is the only spare corner. */
+   the graph, which is the only spare corner.
+
+   The z-index has to clear cytoscape's canvases. The topmost is the
+   edgehandles layer, which the widget puts at 4 (its `stackOrder`
+   option) -- and being transparent, it let the toolbar show through
+   while quietly swallowing every click on it. 10 leaves room for
+   another canvas without going near the panzoom control's 99999. */
 .viz-toolbar {
     position: absolute;
     top: 8px;
     right: 12px;
-    z-index: 3;
+    z-index: 10;
     display: flex;
     gap: 4px;
     background: rgba(255, 255, 255, .92);

--- a/web/app.css
+++ b/web/app.css
@@ -163,6 +163,9 @@ select:focus-visible,
 .diag-line + .diag-line { margin-top: 6px; }
 
 .results { flex: 1 1 auto; display: flex; min-height: 0; }
+/* `display` beats the hidden attribute, so a flex pane that can be
+   switched off has to say so explicitly. */
+.results[hidden] { display: none; }
 .filelist {
     flex: 0 0 240px;
     margin: 0;
@@ -244,3 +247,34 @@ select:focus-visible,
     z-index: 10;
     pointer-events: none;
 }
+
+/* ---- Output tabs: generated code, or the model as a diagram ---- */
+.tabs {
+    display: flex;
+    gap: 2px;
+    margin-left: 12px;
+}
+.tab {
+    font: inherit;
+    padding: 3px 12px;
+    border: 1px solid var(--line, #d0d7de);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    border-radius: 4px;
+}
+.tab.is-active {
+    background: var(--accent, #0969da);
+    border-color: var(--accent, #0969da);
+    color: #fff;
+}
+
+/* The visualizer sizes itself from its container, so this has to be
+   a real box with a height rather than a wrapper that collapses. */
+.viewdiagram {
+    flex: 1 1 auto;
+    min-height: 0;
+    position: relative;
+    overflow: hidden;
+}
+.viewdiagram[hidden] { display: none; }

--- a/web/app.css
+++ b/web/app.css
@@ -43,10 +43,13 @@ body {
 .splitter    { grid-column: 2; }
 .pane-output { grid-column: 3; }
 
+/* Narrow: the panes stack, and the splitter turns on its side. The
+   model pane's size then lives in --model-height, which is what the
+   drag and the arrow keys write in this layout. */
 @media (max-width: 860px) {
     .layout {
         grid-template-columns: 1fr;
-        grid-template-rows: minmax(200px, 40%) 6px 1fr;
+        grid-template-rows: var(--model-height, minmax(200px, 40%)) 6px 1fr;
     }
     .pane-input  { grid-column: 1; grid-row: 1; }
     .splitter    { grid-column: 1; grid-row: 2; cursor: row-resize; }
@@ -68,7 +71,13 @@ body {
 }
 .splitter:hover, .splitter:focus, .splitter.is-dragging { background: #0969da; outline: none; }
 
-.layout.is-collapsed { grid-template-columns: 0 6px 1fr; }
+/* Collapsing zeroes the model pane's track -- the COLUMN one only
+   where there are columns. Below 860px every pane shares column 1,
+   so zeroing it would take the output pane down with it; the stacked
+   layout collapses the row instead (above). */
+@media (min-width: 861px) {
+    .layout.is-collapsed { grid-template-columns: 0 6px 1fr; }
+}
 .layout.is-collapsed .pane-input { display: none; }
 
 .iconbtn {

--- a/web/app.css
+++ b/web/app.css
@@ -109,6 +109,19 @@ body {
 }
 #viewDiagram #simulatorHandle:hover { background: #0969da; }
 
+/* The search box and the pan/zoom control ask for z-index 9999 and
+   99999. Those beat a bootstrap modal (1050), so the simulator's
+   dialogs -- the guard prompt, the payload form, "really change the
+   layout?" -- came up UNDERNEATH them.
+
+   Rather than bid higher for the modal, the two are brought down to
+   just above cytoscape's canvases (which top out at 4) and this
+   toolbar. Dialogs then win by the ordinary rules, which is what
+   those rules are for. Scoped to the diagram view, so nothing here
+   reaches the widget running inside WebGME. */
+#viewDiagram #search { z-index: 20; }
+#viewDiagram .cy-panzoom { z-index: 21; }
+
 /* The widget's toolbar -- print, zoom to fit, auto-layout. WebGME
    puts it in the panel header; here it floats over the top-right of
    the graph, which is the only spare corner.

--- a/web/app.css
+++ b/web/app.css
@@ -119,7 +119,7 @@ body {
    toolbar. Dialogs then win by the ordinary rules, which is what
    those rules are for. Scoped to the diagram view, so nothing here
    reaches the widget running inside WebGME. */
-#viewDiagram #search { z-index: 20; }
+#viewDiagram .search { z-index: 20; }   /* the wrapper carries it, not the input */
 #viewDiagram .cy-panzoom { z-index: 21; }
 
 /* The widget's toolbar -- print, zoom to fit, auto-layout. WebGME

--- a/web/app.css
+++ b/web/app.css
@@ -28,14 +28,76 @@ body {
 .layout {
     flex: 1 1 auto;
     display: grid;
-    grid-template-columns: minmax(320px, 38%) 1fr;
+    /* the model pane's width is a variable so the splitter can move
+       it, and so collapsing is just setting it to zero */
+    grid-template-columns: var(--model-width, minmax(320px, 38%)) 6px 1fr;
     gap: 12px;
     padding: 12px;
     min-height: 0;
 }
+/* Each pane is pinned to its own column. Without this, hiding the
+   model pane takes it out of the flow and everything after it slides
+   left -- the output pane lands in the six-pixel splitter column and
+   the page looks empty. */
+.pane-input  { grid-column: 1; }
+.splitter    { grid-column: 2; }
+.pane-output { grid-column: 3; }
+
 @media (max-width: 860px) {
-    .layout { grid-template-columns: 1fr; grid-template-rows: minmax(200px, 40%) 1fr; }
+    .layout {
+        grid-template-columns: 1fr;
+        grid-template-rows: minmax(200px, 40%) 6px 1fr;
+    }
+    .pane-input  { grid-column: 1; grid-row: 1; }
+    .splitter    { grid-column: 1; grid-row: 2; cursor: row-resize; }
+    .pane-output { grid-column: 1; grid-row: 3; }
+    .layout.is-collapsed { grid-template-rows: 0 6px 1fr; }
 }
+
+/* ---- resizing ------------------------------------------------- */
+
+/* Reading a model and reading its diagram want opposite amounts of
+   room, so the split is the user's to set -- and to collapse
+   entirely, which is what you want once the diagram is the thing you
+   are looking at. */
+.splitter {
+    background: #d0d7de;
+    cursor: col-resize;
+    border-radius: 3px;
+    transition: background .15s;
+}
+.splitter:hover, .splitter:focus, .splitter.is-dragging { background: #0969da; outline: none; }
+
+.layout.is-collapsed { grid-template-columns: 0 6px 1fr; }
+.layout.is-collapsed .pane-input { display: none; }
+
+.iconbtn {
+    font: inherit;
+    font-size: 11px;
+    line-height: 1;
+    padding: 3px 6px;
+    border: 1px solid #d0d7de;
+    background: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #57606a;
+}
+.iconbtn:hover { border-color: #0969da; color: #0969da; }
+
+/* The visualizer's own splitter between the simulator and the graph.
+   The widget implements the dragging itself; WebGME supplies the
+   styling that makes it visible, and without this it is an invisible
+   strip nobody would think to grab.
+
+   Colour only -- NO width. The widget lays those two panels out as
+   floats summing to exactly 100% (19.5 + 0.5 + 80), so a min-width
+   here pushes the total over and wraps the graph underneath the
+   simulator, off the bottom of the page. */
+#viewDiagram #hfsmVizHandle {
+    background: #d0d7de;
+    transition: background .15s;
+}
+#viewDiagram #hfsmVizHandle:hover { background: #0969da; }
 
 .pane {
     display: flex;

--- a/web/app.js
+++ b/web/app.js
@@ -458,6 +458,7 @@
     el('tabDiagram').setAttribute('aria-selected', String(diagram));
     el('viewCode').hidden = diagram;
     el('viewDiagram').hidden = !diagram;
+    el('saveLayoutBtn').hidden = !diagram;
     vizShown = diagram;
     if (diagram) refreshDiagram();
   }
@@ -503,7 +504,114 @@
     });
   }
 
+  /* ------------------- resizing the two panes ------------------- */
+
+  // Reading a model and reading its diagram want opposite amounts of
+  // room, so where the split sits is the user's call. The width lives
+  // in a CSS variable; dragging and collapsing both just set it.
+  function wireSplitter() {
+    var layout = document.querySelector('.layout');
+    var splitter = el('paneSplitter');
+    var collapseBtn = el('collapseModelBtn');
+    var MIN = 180;              // narrower than this and nothing is readable
+    var lastWidth = null;       // what to restore when un-collapsing
+
+    function setWidth(px) {
+      layout.style.setProperty('--model-width', px + 'px');
+    }
+
+    function collapsed() {
+      return layout.classList.contains('is-collapsed');
+    }
+
+    function setCollapsed(yes) {
+      layout.classList.toggle('is-collapsed', yes);
+      collapseBtn.setAttribute('aria-expanded', String(!yes));
+      collapseBtn.innerHTML = (yes ? '&#9654;' : '&#9664;') + ' Model';
+      collapseBtn.title = yes
+        ? 'Show the model text'
+        : 'Hide the model text (the diagram keeps the whole width)';
+      if (!yes && lastWidth) setWidth(lastWidth);
+      // the graph sizes itself from its container, so it has to be
+      // told the container changed
+      resizeDiagram();
+    }
+
+    function onDrag(event) {
+      var x = event.clientX - layout.getBoundingClientRect().left;
+      var max = layout.clientWidth - MIN;
+      lastWidth = Math.max(MIN, Math.min(x, max));
+      setWidth(lastWidth);
+    }
+
+    function stopDrag() {
+      splitter.classList.remove('is-dragging');
+      document.removeEventListener('mousemove', onDrag);
+      document.removeEventListener('mouseup', stopDrag);
+      // resize once at the end: cytoscape re-measuring on every
+      // mousemove makes the drag stutter
+      resizeDiagram();
+    }
+
+    splitter.addEventListener('mousedown', function (event) {
+      if (collapsed()) return;
+      event.preventDefault();
+      splitter.classList.add('is-dragging');
+      document.addEventListener('mousemove', onDrag);
+      document.addEventListener('mouseup', stopDrag);
+    });
+
+    splitter.addEventListener('dblclick', function () { setCollapsed(!collapsed()); });
+    collapseBtn.addEventListener('click', function () { setCollapsed(!collapsed()); });
+
+    // keyboard: a splitter nobody can reach without a mouse is not a
+    // control, it is a decoration
+    splitter.addEventListener('keydown', function (event) {
+      var step = event.shiftKey ? 64 : 16;
+      var current = lastWidth ||
+        document.querySelector('.pane-input').getBoundingClientRect().width;
+      if (event.key === 'ArrowLeft') lastWidth = Math.max(MIN, current - step);
+      else if (event.key === 'ArrowRight') {
+        lastWidth = Math.min(layout.clientWidth - MIN, current + step);
+      } else if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        setCollapsed(!collapsed());
+        return;
+      } else return;
+      event.preventDefault();
+      setWidth(lastWidth);
+      resizeDiagram();
+    });
+  }
+
+  // the diagram draws on a canvas sized to its container, so a layout
+  // change has to be handed to it explicitly
+  function resizeDiagram() {
+    if (vizModule && vizModule.resize) vizModule.resize();
+  }
+
+  // Dragging a state writes its new position straight into the
+  // model the diagram is running on. This is how that gets back into
+  // the text -- explicitly, because rewriting the editor under the
+  // user on every drag would fight whatever they are typing.
+  function saveLayout() {
+    if (!vizModule || !vizModule.current()) {
+      showDiagnostics(['Nothing to save: the diagram is not showing a model.'],
+                      'error');
+      return;
+    }
+    var text = vizModule.currentModelJSON();
+    if (!text) return;
+    setModelText(text);
+    vizModelText = text.trim();   // the diagram already matches it
+    showDiagnostics([]);
+    setStatus('layout saved to the model');
+  }
+
   function wire() {
+    el('saveLayoutBtn').addEventListener('click', saveLayout);
+    wireSplitter();
+    window.addEventListener('resize', resizeDiagram);
     el('tabCode').addEventListener('click', function () { showTab('code'); });
     el('tabDiagram').addEventListener('click', function () { showTab('diagram'); });
     el('generateBtn').addEventListener('click', generate);

--- a/web/app.js
+++ b/web/app.js
@@ -377,6 +377,13 @@
       return extensionOf(n) === 'hpp';
     })[0] || Object.keys(artifacts).sort()[0];
     if (first) showFile(first);
+
+    // Loading an example or a file generates, so this is also how a
+    // newly loaded model reaches an already-open Diagram tab. It is
+    // deliberately NOT hooked to typing: redrawing takes the layout
+    // with it, and doing that on every keystroke would throw away
+    // work nobody asked to discard.
+    refreshDiagram({ keepStatus: true });
   }
 
   function loadExampleList() {
@@ -463,11 +470,29 @@
     if (diagram) refreshDiagram();
   }
 
-  function refreshDiagram() {
+  // Take the diagram down. A machine left on screen next to an error
+  // message reads as though the error were about what is drawn, and
+  // it leaves `Save layout` pointing at a model the text no longer
+  // contains.
+  function clearDiagram() {
+    if (vizModule) vizModule.destroy();
+    vizModelText = null;
+  }
+
+  /**
+   * @param opts.keepStatus  leave the status line and the diagnostics
+   *   alone when the drawing succeeds -- generate() has just written
+   *   a more useful summary there ("12 files . 2 warnings"), and the
+   *   redraw is a side effect of what it did, not the thing asked for
+   */
+  function refreshDiagram(opts) {
     if (!vizShown) return;
+    var quiet = !!(opts && opts.keepStatus);
     var raw = getModelText().trim();
     if (!raw) {
+      clearDiagram();
       showDiagnostics(['Nothing to draw: paste or load a model first.'], 'error');
+      setStatus('nothing to draw', 'error');
       return;
     }
     if (raw === vizModelText && vizModule && vizModule.current()) {
@@ -478,18 +503,22 @@
     try {
       model = JSON.parse(raw);
     } catch (e) {
+      clearDiagram();
       showDiagnostics(['The model is not valid JSON: ' + e.message], 'error');
+      setStatus('parse error', 'error');
       return;
     }
 
-    setStatus('drawing...');
+    if (!quiet) setStatus('drawing...');
     requirejs(['viz'], function (viz) {
       vizModule = viz;
       try {
         viz.mount(el('viewDiagram'), model);
         vizModelText = raw;
-        showDiagnostics([]);
-        setStatus('ready');
+        if (!quiet) {
+          showDiagnostics([]);
+          setStatus('ready');
+        }
       } catch (e) {
         // the diagram resolves the model exactly as the generator
         // does, so an ill-typed model fails here the same way
@@ -507,17 +536,34 @@
   /* ------------------- resizing the two panes ------------------- */
 
   // Reading a model and reading its diagram want opposite amounts of
-  // room, so where the split sits is the user's call. The width lives
+  // room, so where the split sits is the user's call. The size lives
   // in a CSS variable; dragging and collapsing both just set it.
+  //
+  // The split turns on its side on a narrow screen -- the panes stack,
+  // and the same bar then moves the boundary up and down. Everything
+  // here therefore works in "size along the splitter's axis" rather
+  // than in width, or the control would be inert in exactly the
+  // layout where space is tightest.
   function wireSplitter() {
     var layout = document.querySelector('.layout');
     var splitter = el('paneSplitter');
     var collapseBtn = el('collapseModelBtn');
-    var MIN = 180;              // narrower than this and nothing is readable
-    var lastWidth = null;       // what to restore when un-collapsing
+    var stacked = window.matchMedia('(max-width: 860px)');
+    var lastSize = null;        // what to restore when un-collapsing
 
-    function setWidth(px) {
-      layout.style.setProperty('--model-width', px + 'px');
+    // narrower/shorter than this and nothing in the pane is readable
+    function minSize() { return stacked.matches ? 120 : 180; }
+    function totalSize() {
+      return stacked.matches ? layout.clientHeight : layout.clientWidth;
+    }
+    function paneSize() {
+      var box = document.querySelector('.pane-input').getBoundingClientRect();
+      return stacked.matches ? box.height : box.width;
+    }
+
+    function setSize(px) {
+      layout.style.setProperty(
+        stacked.matches ? '--model-height' : '--model-width', px + 'px');
     }
 
     function collapsed() {
@@ -531,17 +577,35 @@
       collapseBtn.title = yes
         ? 'Show the model text'
         : 'Hide the model text (the diagram keeps the whole width)';
-      if (!yes && lastWidth) setWidth(lastWidth);
+      if (!yes && lastSize) setSize(lastSize);
       // the graph sizes itself from its container, so it has to be
       // told the container changed
       resizeDiagram();
     }
 
+    // A separator BETWEEN left and right panes is itself vertical; one
+    // between stacked panes is horizontal. Screen readers announce the
+    // arrow keys from this, so it has to follow the layout.
+    function syncOrientation() {
+      splitter.setAttribute('aria-orientation',
+                            stacked.matches ? 'horizontal' : 'vertical');
+      // measured along the other axis, so it means nothing now
+      lastSize = null;
+    }
+    syncOrientation();
+    if (stacked.addEventListener) {
+      stacked.addEventListener('change', syncOrientation);
+    } else if (stacked.addListener) {
+      stacked.addListener(syncOrientation);   // Safari < 14
+    }
+
     function onDrag(event) {
-      var x = event.clientX - layout.getBoundingClientRect().left;
-      var max = layout.clientWidth - MIN;
-      lastWidth = Math.max(MIN, Math.min(x, max));
-      setWidth(lastWidth);
+      var box = layout.getBoundingClientRect();
+      var along = stacked.matches
+        ? event.clientY - box.top
+        : event.clientX - box.left;
+      lastSize = Math.max(minSize(), Math.min(along, totalSize() - minSize()));
+      setSize(lastSize);
     }
 
     function stopDrag() {
@@ -565,21 +629,25 @@
     collapseBtn.addEventListener('click', function () { setCollapsed(!collapsed()); });
 
     // keyboard: a splitter nobody can reach without a mouse is not a
-    // control, it is a decoration
+    // control, it is a decoration. Both arrow pairs are accepted in
+    // both layouts -- the one that matches the orientation is the
+    // obvious choice, and the other is no worse than doing nothing.
+    var SMALLER = { ArrowLeft: true, ArrowUp: true };
+    var BIGGER = { ArrowRight: true, ArrowDown: true };
     splitter.addEventListener('keydown', function (event) {
       var step = event.shiftKey ? 64 : 16;
-      var current = lastWidth ||
-        document.querySelector('.pane-input').getBoundingClientRect().width;
-      if (event.key === 'ArrowLeft') lastWidth = Math.max(MIN, current - step);
-      else if (event.key === 'ArrowRight') {
-        lastWidth = Math.min(layout.clientWidth - MIN, current + step);
+      var current = lastSize || paneSize();
+      if (SMALLER[event.key]) {
+        lastSize = Math.max(minSize(), current - step);
+      } else if (BIGGER[event.key]) {
+        lastSize = Math.min(totalSize() - minSize(), current + step);
       } else if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         setCollapsed(!collapsed());
         return;
       } else return;
       event.preventDefault();
-      setWidth(lastWidth);
+      setSize(lastSize);
       resizeDiagram();
     });
   }
@@ -598,6 +666,17 @@
     if (!vizModule || !vizModule.current()) {
       showDiagnostics(['Nothing to save: the diagram is not showing a model.'],
                       'error');
+      return;
+    }
+    // The model text sits beside the diagram, so it can have moved on
+    // since the diagram was drawn -- and what gets written back is the
+    // machine the diagram is running, not the one in the editor.
+    // Saving anyway would silently throw away whatever was typed.
+    if (getModelText().trim() !== vizModelText) {
+      showDiagnostics(['The model text has changed since the diagram was ' +
+                       'drawn, and saving would overwrite it. Press Generate ' +
+                       'to redraw from the current text first.'], 'error');
+      setStatus('layout not saved', 'error');
       return;
     }
     var text = vizModule.currentModelJSON();

--- a/web/app.js
+++ b/web/app.js
@@ -25,6 +25,33 @@
       'text': 'vendor/text',
       'hfsm': 'src/common',
       'templates': 'src/plugins/SoftwareGenerator/templates',
+
+      // the visualizer, copied in verbatim, names its dependencies
+      // the way it does inside WebGME -- so they are mapped, not
+      // rewritten. See scripts/build-web.sh.
+      'widgets': 'src/visualizers/widgets',
+      'decorators': 'src/decorators',
+      'bower': 'vendor/bower',
+      'q': 'vendor/q',
+      'css': 'vendor/css.min',
+      'jquery': 'vendor/jquery.min',
+      'bootstrap': 'vendor/bootstrap.min',
+      'cytoscape-edgehandles': 'vendor/bower/cytoscape-edgehandles/cytoscape-edgehandles',
+      'cytoscape-context-menus': 'vendor/bower/cytoscape-context-menus/cytoscape-context-menus',
+      'cytoscape-panzoom': 'vendor/bower/cytoscape-panzoom/cytoscape-panzoom',
+    },
+    // cytoscape's plugins register themselves on the library, so it
+    // has to be there before they run
+    shim: {
+      // bootstrap is a jQuery plugin: it needs jQuery on the page
+      // before it runs, and exports nothing of its own
+      'bootstrap': { deps: ['jquery'] },
+      'cytoscape-edgehandles': { deps: ['bower/cytoscape/dist/cytoscape.min'] },
+      'cytoscape-context-menus': { deps: ['bower/cytoscape/dist/cytoscape.min'] },
+      'cytoscape-panzoom': { deps: ['bower/cytoscape/dist/cytoscape.min'] },
+      'bower/cytoscape-cose-bilkent/cytoscape-cose-bilkent': {
+        deps: ['bower/cytoscape/dist/cytoscape.min'],
+      },
     },
     // The default is 7s, which the generator can exceed on a slow
     // link or a single-threaded static server: it pulls every
@@ -414,7 +441,71 @@
     });
   }
 
+  /* ---------------------- the Diagram tab ---------------------- */
+
+  // loaded on first use: the visualizer pulls in cytoscape and its
+  // plugins, which is a lot to fetch for someone who only wants the
+  // generated code
+  var vizModule = null;
+  var vizShown = false;
+  var vizModelText = null;   // what the diagram was last built from
+
+  function showTab(which) {
+    var diagram = which === 'diagram';
+    el('tabCode').classList.toggle('is-active', !diagram);
+    el('tabDiagram').classList.toggle('is-active', diagram);
+    el('tabCode').setAttribute('aria-selected', String(!diagram));
+    el('tabDiagram').setAttribute('aria-selected', String(diagram));
+    el('viewCode').hidden = diagram;
+    el('viewDiagram').hidden = !diagram;
+    vizShown = diagram;
+    if (diagram) refreshDiagram();
+  }
+
+  function refreshDiagram() {
+    if (!vizShown) return;
+    var raw = getModelText().trim();
+    if (!raw) {
+      showDiagnostics(['Nothing to draw: paste or load a model first.'], 'error');
+      return;
+    }
+    if (raw === vizModelText && vizModule && vizModule.current()) {
+      return;   // already showing this model
+    }
+
+    var model;
+    try {
+      model = JSON.parse(raw);
+    } catch (e) {
+      showDiagnostics(['The model is not valid JSON: ' + e.message], 'error');
+      return;
+    }
+
+    setStatus('drawing...');
+    requirejs(['viz'], function (viz) {
+      vizModule = viz;
+      try {
+        viz.mount(el('viewDiagram'), model);
+        vizModelText = raw;
+        showDiagnostics([]);
+        setStatus('ready');
+      } catch (e) {
+        // the diagram resolves the model exactly as the generator
+        // does, so an ill-typed model fails here the same way
+        viz.destroy();
+        vizModelText = null;
+        showDiagnostics([String(e.message || e)], 'error');
+        setStatus('model rejected');
+      }
+    }, function (err) {
+      showDiagnostics(['Could not load the visualizer: ' + err.message], 'error');
+      setStatus('error');
+    });
+  }
+
   function wire() {
+    el('tabCode').addEventListener('click', function () { showTab('code'); });
+    el('tabDiagram').addEventListener('click', function () { showTab('diagram'); });
     el('generateBtn').addEventListener('click', generate);
     el('fileInput').addEventListener('change', function (e) {
       var f = e.target.files && e.target.files[0];

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>HFSM Playground</title>
 <link rel="stylesheet" href="vendor/bootstrap.min.css"/>
+<link rel="stylesheet" href="vendor/font-awesome/css/font-awesome.min.css"/>
 <link rel="stylesheet" href="vendor/codemirror/lib/codemirror.css"/>
 <link rel="stylesheet" href="app.css"/>
 </head>

--- a/web/index.html
+++ b/web/index.html
@@ -45,9 +45,18 @@
     </div>
   </section>
 
+  <div id="paneSplitter" class="splitter" role="separator"
+       aria-orientation="vertical" tabindex="0"
+       aria-label="Resize the model pane" title="Drag to resize, double-click to collapse"></div>
+
   <section class="pane pane-output">
     <div class="pane-head">
       <h2>Output</h2>
+      <!-- lives here, not in the model pane's own header: a button
+           that disappears along with what it hides leaves no way back -->
+      <button id="collapseModelBtn" class="iconbtn" type="button"
+              aria-expanded="true"
+              title="Hide the model text (the diagram keeps the whole width)">&#9664; Model</button>
       <div class="tabs" role="tablist" aria-label="Output view">
         <button id="tabCode" class="tab is-active" type="button"
                 role="tab" aria-selected="true" aria-controls="viewCode">Code</button>
@@ -55,6 +64,8 @@
                 role="tab" aria-selected="false" aria-controls="viewDiagram">Diagram</button>
       </div>
       <div class="controls">
+        <button id="saveLayoutBtn" type="button" hidden
+                title="Write the positions you dragged back into the model text">Save layout</button>
         <span id="status" class="status" role="status" aria-live="polite"></span>
         <button id="downloadAllBtn" type="button" disabled>Download all</button>
       </div>

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>HFSM Playground</title>
+<link rel="stylesheet" href="vendor/bootstrap.min.css"/>
 <link rel="stylesheet" href="vendor/codemirror/lib/codemirror.css"/>
 <link rel="stylesheet" href="app.css"/>
 </head>
@@ -47,13 +48,21 @@
   <section class="pane pane-output">
     <div class="pane-head">
       <h2>Output</h2>
+      <div class="tabs" role="tablist" aria-label="Output view">
+        <button id="tabCode" class="tab is-active" type="button"
+                role="tab" aria-selected="true" aria-controls="viewCode">Code</button>
+        <button id="tabDiagram" class="tab" type="button"
+                role="tab" aria-selected="false" aria-controls="viewDiagram">Diagram</button>
+      </div>
       <div class="controls">
         <span id="status" class="status" role="status" aria-live="polite"></span>
         <button id="downloadAllBtn" type="button" disabled>Download all</button>
       </div>
     </div>
     <div id="diagnostics" class="diagnostics" hidden></div>
-    <div class="results">
+    <div id="viewDiagram" class="viewdiagram" role="tabpanel"
+         aria-labelledby="tabDiagram" hidden></div>
+    <div id="viewCode" class="results" role="tabpanel" aria-labelledby="tabCode">
       <ul id="fileList" class="filelist" aria-label="Generated files"></ul>
       <div class="viewer">
         <div class="viewer-head">
@@ -71,6 +80,12 @@
 
 <div id="dropOverlay" class="dropoverlay" hidden>Drop a model .json</div>
 
+<!-- jQuery and bootstrap load through requirejs, not as plain
+     scripts: the visualizer's bundled typeahead asks for a 'jquery'
+     MODULE, and a jQuery loaded before require.js never registers
+     one. Loaded this way it still sets the globals the widget uses.
+     bootstrap.min.css comes BEFORE app.css so the playground's own
+     styling wins. -->
 <script src="vendor/require.js"></script>
 <script src="app.js"></script>
 </body>

--- a/web/viz.js
+++ b/web/viz.js
@@ -100,6 +100,22 @@ define([
       HostServices.none()
     );
 
+    // A state machine reads as a flow from its initial state, so
+    // breadthfirst suits it -- and, unlike WebGME's cose-bilkent, it
+    // demonstrably moves the nodes here. cose-bilkent registers and
+    // reports a completed run in this page but leaves every position
+    // untouched, while the same file rearranges the same kind of graph
+    // inside WebGME; the cause is not yet known, so the playground
+    // uses a layout whose result can be seen.
+    widget.setLayoutOptions({
+      name: 'breadthfirst',
+      directed: true,
+      spacingFactor: 1.1,
+      animate: false,
+      fit: true,
+      padding: 30,
+    });
+
     // The same toolbar WebGME's panel installs -- print the graph to
     // a PNG, zoom to fit, run the auto-layout. The widget builds the
     // buttons and wires them; all a host does is say where they go,
@@ -123,18 +139,7 @@ define([
     // compute one instead. If the model DOES carry positions they are
     // the author's and are left alone.
     if (!anyPositions) {
-      // breadthfirst, not the toolbar's cose-bilkent: a state machine
-      // reads as a flow from its initial state, and the force-directed
-      // layout has nothing but edges to go on, so it piles the nested
-      // compound boxes on top of each other.
-      widget.reLayout({
-        name: 'breadthfirst',
-        directed: true,
-        spacingFactor: 1.1,
-        animate: false,
-        fit: true,
-        padding: 30,
-      });
+      widget.reLayout();
     }
 
     // the feed is over, so the warnings it produced along the way --

--- a/web/viz.js
+++ b/web/viz.js
@@ -100,6 +100,14 @@ define([
       HostServices.none()
     );
 
+    // The same toolbar WebGME's panel installs -- print the graph to
+    // a PNG, zoom to fit, run the auto-layout. The widget builds the
+    // buttons and wires them; all a host does is say where they go,
+    // so there is no second copy of any of it here.
+    var toolbar = $('<div class="viz-toolbar"></div>');
+    $(container).find('#hfsmVizRight').first().append(toolbar);
+    widget._addSplitPanelToolbarBtns(toolbar);
+
     // Feed the graph. Order does not matter: the widget defers any
     // node whose parent or endpoints have not arrived yet.
     var anyPositions = false;

--- a/web/viz.js
+++ b/web/viz.js
@@ -14,6 +14,7 @@
  */
 define([
   'jquery',
+  'underscore',
   'bower/cytoscape/dist/cytoscape.min',
   'bower/cytoscape-cose-bilkent/cytoscape-cose-bilkent',
   'cytoscape-edgehandles',
@@ -23,25 +24,32 @@ define([
   'hfsm/viz/LocalBackend',
   'hfsm/viz/HostServices',
   'hfsm/viz/describe',
+  'hfsm/exportModel',
   'widgets/HFSMViz/HFSMVizWidget',
   // the dialogs are bootstrap modals; nothing imports it, so it is
   // listed here to guarantee it is on the page before one opens
   'bootstrap',
-], function ($, cytoscape, coseBilkent, edgehandles, contextMenus, panzoom,
-             resolveModel, LocalBackend, HostServices, describe,
+], function ($, _, cytoscape, coseBilkent, edgehandles, contextMenus, panzoom,
+             resolveModel, LocalBackend, HostServices, describe, exportModel,
              HFSMVizWidget) {
   'use strict';
 
   // Cytoscape's extensions are UMD bundles that EXPORT a register
   // function and self-register only against a global `cytoscape`.
   // Loaded as AMD modules there is no global, so nothing registers
-  // them: the layout then runs and moves nothing, and the panzoom
-  // control never appears -- both silently, which is what makes this
-  // worth spelling out. WebGME gets away without it because cytoscape
-  // is a global there.
-  [coseBilkent, edgehandles, contextMenus, panzoom].forEach(function (ext) {
-    if (typeof ext === 'function') ext(cytoscape);
-  });
+  // them. WebGME gets away without this because cytoscape is a global
+  // there.
+  //
+  // Each register function takes DIFFERENT arguments, and they fail
+  // quietly when they do not get them -- edgehandles without its
+  // debounce/throttle leaves a drag that never ends, so a click picks
+  // a node up and never puts it down. Getting these wrong costs an
+  // afternoon, so they are spelled out one at a time rather than
+  // looped over.
+  coseBilkent(cytoscape);
+  edgehandles(cytoscape, _.debounce.bind(_), _.throttle.bind(_));
+  contextMenus(cytoscape, $);
+  panzoom(cytoscape, $);
 
   // The widget forks a logger; console is close enough for a page
   // with no logging framework behind it.
@@ -58,12 +66,14 @@ define([
 
   var widget = null;
   var backend = null;
+  var model = null;
 
   function destroy() {
     if (widget) {
       try { widget.destroy(); } catch (e) { console.error(e); }
       widget = null;
       backend = null;
+      model = null;
     }
   }
 
@@ -80,7 +90,7 @@ define([
 
     // resolve a COPY: resolveModel fills in parents, defaults and
     // childPaths in place, and the caller's object is the user's
-    var model = JSON.parse(JSON.stringify(rawModel));
+    model = JSON.parse(JSON.stringify(rawModel));
     resolveModel.resolve(model);
 
     backend = LocalBackend(model);
@@ -126,9 +136,47 @@ define([
     return backend;
   }
 
+  /**
+   * Re-measure after the container changed size. Cytoscape draws on a
+   * canvas sized at creation, so without this the graph keeps the
+   * dimensions it had when the pane was a different width.
+   */
+  function resize() {
+    if (widget && widget._cy) {
+      widget._cy.resize();
+    }
+  }
+
+  /**
+   * The model as it now stands, positions included -- dragging a
+   * state writes straight through the backend, so this is how that
+   * work gets back out to somewhere it can be saved.
+   */
+  function currentModelJSON() {
+    if (!backend || !widget || !widget._cy) return null;
+
+    // Take the positions from the GRAPH, not just from whatever was
+    // dragged. A model that arrived without a layout was arranged
+    // automatically, and that arrangement is just as much "how the
+    // diagram looks" as a drag is -- saving only the drags would
+    // leave the next load to arrange it all over again, differently.
+    widget._cy.nodes().forEach(function (node) {
+      var object = model.objects[node.id()];
+      if (!object) return;
+      var p = node.position();
+      if (typeof p.x === 'number' && typeof p.y === 'number') {
+        object.position = { x: p.x, y: p.y };
+      }
+    });
+
+    return exportModel.toJSON(model, {});
+  }
+
   return {
     mount: mount,
     destroy: destroy,
+    resize: resize,
+    currentModelJSON: currentModelJSON,
     /** the mounted widget, for the page to resize / refresh */
     current: function () { return widget; },
   };

--- a/web/viz.js
+++ b/web/viz.js
@@ -1,0 +1,135 @@
+/**
+ * Mounts the HFSM visualizer -- the SAME widget and simulator WebGME
+ * runs -- over a plain JSON model in the playground.
+ *
+ * There is no WebGME here: no client, no territories, no server. The
+ * widget takes its model through a ModelBackend and its UI services
+ * through HostServices, so all this has to supply is a LocalBackend
+ * over the parsed JSON and a host that offers nothing (the playground
+ * is read-only for now -- editing is the next step).
+ *
+ * The node feed mirrors what the WebGME control does: build a
+ * descriptor per object and hand each to the widget, which sorts out
+ * the ordering itself through its own dependency tracking.
+ */
+define([
+  'jquery',
+  'bower/cytoscape/dist/cytoscape.min',
+  'bower/cytoscape-cose-bilkent/cytoscape-cose-bilkent',
+  'cytoscape-edgehandles',
+  'cytoscape-context-menus',
+  'cytoscape-panzoom',
+  'hfsm/resolveModel',
+  'hfsm/viz/LocalBackend',
+  'hfsm/viz/HostServices',
+  'hfsm/viz/describe',
+  'widgets/HFSMViz/HFSMVizWidget',
+  // the dialogs are bootstrap modals; nothing imports it, so it is
+  // listed here to guarantee it is on the page before one opens
+  'bootstrap',
+], function ($, cytoscape, coseBilkent, edgehandles, contextMenus, panzoom,
+             resolveModel, LocalBackend, HostServices, describe,
+             HFSMVizWidget) {
+  'use strict';
+
+  // Cytoscape's extensions are UMD bundles that EXPORT a register
+  // function and self-register only against a global `cytoscape`.
+  // Loaded as AMD modules there is no global, so nothing registers
+  // them: the layout then runs and moves nothing, and the panzoom
+  // control never appears -- both silently, which is what makes this
+  // worth spelling out. WebGME gets away without it because cytoscape
+  // is a global there.
+  [coseBilkent, edgehandles, contextMenus, panzoom].forEach(function (ext) {
+    if (typeof ext === 'function') ext(cytoscape);
+  });
+
+  // The widget forks a logger; console is close enough for a page
+  // with no logging framework behind it.
+  function makeLogger(name) {
+    function noop() {}
+    return {
+      fork: function (child) { return makeLogger(name + ':' + child); },
+      debug: noop,
+      info: noop,
+      warn: function () { console.warn.apply(console, arguments); },
+      error: function () { console.error.apply(console, arguments); },
+    };
+  }
+
+  var widget = null;
+  var backend = null;
+
+  function destroy() {
+    if (widget) {
+      try { widget.destroy(); } catch (e) { console.error(e); }
+      widget = null;
+      backend = null;
+    }
+  }
+
+  /**
+   * @param container  the element to draw into
+   * @param rawModel   the model as parsed from the editor; resolved
+   *                   here so the diagram shows exactly what the
+   *                   generator would consume, ill-typed models
+   *                   included -- they throw, and the caller reports
+   * @return the LocalBackend, so callers can read the model back
+   */
+  function mount(container, rawModel) {
+    destroy();
+
+    // resolve a COPY: resolveModel fills in parents, defaults and
+    // childPaths in place, and the caller's object is the user's
+    var model = JSON.parse(JSON.stringify(rawModel));
+    resolveModel.resolve(model);
+
+    backend = LocalBackend(model);
+    widget = new HFSMVizWidget(
+      makeLogger('HFSMViz'), $(container), null,
+      function () { return backend; },
+      HostServices.none()
+    );
+
+    // Feed the graph. Order does not matter: the widget defers any
+    // node whose parent or endpoints have not arrived yet.
+    var anyPositions = false;
+    Object.keys(model.objects).sort().forEach(function (path) {
+      if (model.objects[path].position) anyPositions = true;
+      var desc = describe.finish(backend.getNode(path));
+      if (desc) widget.addNode(desc);
+    });
+
+    // A model authored by hand -- or exported by the CLI -- carries no
+    // layout, so every node would sit at (0, 0) in a heap. WebGME
+    // models have positions because the editor saved them; here we
+    // compute one instead. If the model DOES carry positions they are
+    // the author's and are left alone.
+    if (!anyPositions) {
+      // breadthfirst, not the toolbar's cose-bilkent: a state machine
+      // reads as a flow from its initial state, and the force-directed
+      // layout has nothing but edges to go on, so it piles the nested
+      // compound boxes on top of each other.
+      widget.reLayout({
+        name: 'breadthfirst',
+        directed: true,
+        spacingFactor: 1.1,
+        animate: false,
+        fit: true,
+        padding: 30,
+      });
+    }
+
+    // the feed is over, so the warnings it produced along the way --
+    // about a model that was still arriving -- are no longer true
+    widget.clearSimulationLog();
+
+    return backend;
+  }
+
+  return {
+    mount: mount,
+    destroy: destroy,
+    /** the mounted widget, for the page to resize / refresh */
+    current: function () { return widget; },
+  };
+});

--- a/web/viz.js
+++ b/web/viz.js
@@ -101,12 +101,10 @@ define([
     );
 
     // A state machine reads as a flow from its initial state, so
-    // breadthfirst suits it -- and, unlike WebGME's cose-bilkent, it
-    // demonstrably moves the nodes here. cose-bilkent registers and
-    // reports a completed run in this page but leaves every position
-    // untouched, while the same file rearranges the same kind of graph
-    // inside WebGME; the cause is not yet known, so the playground
-    // uses a layout whose result can be seen.
+    // breadthfirst suits it. The toolbar offers every other layout the
+    // page has registered, cose-bilkent included -- see
+    // `layoutInput` for why that one needs the local transitions kept
+    // out of its input before it will run at all.
     widget.setLayoutOptions({
       name: 'breadthfirst',
       directed: true,

--- a/web/viz.js
+++ b/web/viz.js
@@ -71,10 +71,14 @@ define([
   function destroy() {
     if (widget) {
       try { widget.destroy(); } catch (e) { console.error(e); }
-      widget = null;
-      backend = null;
-      model = null;
     }
+    // cleared whatever happened above, and whether or not a widget
+    // was ever built: `mount` sets the backend before the widget, so
+    // a constructor that throws part-way would otherwise leave this
+    // module holding a model nothing is showing.
+    widget = null;
+    backend = null;
+    model = null;
   }
 
   /**
@@ -124,19 +128,32 @@ define([
 
     // Feed the graph. Order does not matter: the widget defers any
     // node whose parent or endpoints have not arrived yet.
-    var anyPositions = false;
+    var unpositioned = 0;
     Object.keys(model.objects).sort().forEach(function (path) {
-      if (model.objects[path].position) anyPositions = true;
       var desc = describe.finish(backend.getNode(path));
-      if (desc) widget.addNode(desc);
+      if (!desc) return;
+      widget.addNode(desc);
+      // an edge is drawn from its endpoints, so only the boxes need a
+      // position of their own
+      if (!desc.isConnection && !model.objects[path].position) {
+        unpositioned++;
+      }
     });
 
     // A model authored by hand -- or exported by the CLI -- carries no
     // layout, so every node would sit at (0, 0) in a heap. WebGME
     // models have positions because the editor saved them; here we
-    // compute one instead. If the model DOES carry positions they are
-    // the author's and are left alone.
-    if (!anyPositions) {
+    // compute one instead. If every drawable node carries a position
+    // it is the author's, and it is left alone.
+    //
+    // A PARTIALLY positioned model is arranged too, rather than only
+    // when nothing is placed: cytoscape's layouts move everything
+    // they are handed, so there is no placing just the nodes that are
+    // missing coordinates. Of the two whole-graph answers, arranging
+    // it all at least produces a readable diagram, where honouring a
+    // partial layout would leave the rest stacked on top of each
+    // other at (0, 0).
+    if (unpositioned) {
       widget.reLayout();
     }
 


### PR DESCRIPTION
The static playground gets a **Diagram** tab: the model rendered as a UML state chart, with the simulator running against it. No server, no database, no WebGME.

It is the *same* widget and simulator WebGME runs, copied in verbatim. Phase A put the model behind `ModelBackend` and Phase B put the host UI behind `HostServices`, so all this adds is the wiring:

```js
new HFSMVizWidget(logger, container, null,
                  function () { return LocalBackend(model); },
                  HostServices.none());
```

The build copies the visualizer and its front-end libraries with the `bower/...` module ids preserved — rewriting ids is exactly the drift this build exists to prevent. The two WebGME adapters are deliberately **not** shipped, and their absence is checked rather than assumed.

## Four things that were not visible from the code

**cytoscape's extensions never registered.** They are UMD bundles that export a register function and self-register only against a *global* `cytoscape`. Loaded as AMD modules there is no global, so nothing registered them — the layout ran and moved nothing, the panzoom control never appeared, both silently. `viz.js` registers them explicitly. WebGME gets away without it because cytoscape is a global there.

**`display: flex` beats the `hidden` attribute**, so the code pane stayed visible underneath the diagram until `.results[hidden]` said otherwise. Same trap as the drop overlay in the earlier playground work.

**Hand-authored models carry no positions.** WebGME models have them because the editor saved them; a model from the CLI or a fixture has none, so every node landed at (0,0) in a heap. A model without positions now gets a `breadthfirst` layout, which reads as a flow from the initial state. The toolbar's force-directed layout has only edges to go on and piles the nested compound boxes on top of each other. Models that *do* carry positions keep the author's.

**Loading feeds the widget one node at a time**, and the checks it runs along the way report on a model that is still half-built — true at that moment, noise once it is all there. The log is cleared when the feed finishes.

## Shared rules, not a second copy

`src/common/viz/describe.js` holds the label rules both hosts use, so a transition reads `EVENT [guard]` in the playground exactly as in WebGME. `HFSMVizWidget.reLayout` grew an optional overrides argument so a host can ask for a different layout instead of reaching into `_cy`.

## Verification

`verify-web-build` now byte-compares every copied source, fails if a WebGME adapter ships, and scans the shipped tree for WebGME module references. All three negative-tested (planted adapter, tampered copy, planted `js/` reference).

In the browser: the Features example draws with nesting, history and choice pseudostates, and clicking `NEXT` moves the active state `StateA1 -> StateA2` with the transition logged. WebGME re-checked and unchanged.

## Next

Phase D — editing. `LocalBackend` already enforces the metamodel, so the remaining work is a palette and the plain-DOM `contextMenu` / `makeDroppable` that `HostServices.none()` currently stands in for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy