### PR TITLE
Phase D: the playground edits models

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,15 +11,23 @@ on:
       - 'web/**'
       - 'src/common/**'
       - 'src/plugins/SoftwareGenerator/templates/**'
+      # the playground ships the visualizer itself, so a change to the
+      # widget, its stylesheets or the decorator SVGs belongs in the
+      # deployed page too
+      - 'src/visualizers/widgets/HFSMViz/**'
+      - 'src/decorators/UMLStateMachineDecorator/**'
+      - 'src/svgs/**'
       - 'test/fixtures/**'
       - 'scripts/build-web.sh'
       # the verifier gates publication, so a fix to it must be able to
       # rerun a failed deploy
       - 'scripts/verify-web-build.js'
       # dependency versions decide which CodeMirror / RequireJS /
-      # handlebars / underscore actually get vendored
+      # handlebars / underscore actually get vendored, and bower.json
+      # pins the cytoscape family the diagram is drawn with
       - 'package.json'
       - 'package-lock.json'
+      - 'bower.json'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -47,6 +55,21 @@ jobs:
         run: >
           npm install --no-save --no-package-lock --ignore-scripts
           requirejs requirejs-text handlebars underscore
+
+      # The playground ships the visualizer, so it needs the same
+      # front-end libraries WebGME serves -- at the SAME versions,
+      # which is the point of vendoring them rather than picking
+      # replacements. bower.json pins the cytoscape family; the rest
+      # (jquery, bootstrap, require-css, font-awesome, q) come from
+      # webgme's own dependencies, exactly as they do at runtime.
+      #
+      # This is the same pair of steps ci.yml's web-playground job
+      # runs. Without them the build stops at cytoscape, which is how
+      # this workflow broke the moment the diagram was added.
+      - name: Install the visualizer's front-end libraries
+        run: |
+          npm install --no-save --no-package-lock --ignore-scripts webgme bower
+          ./node_modules/.bin/bower install --allow-root
 
       - name: Build the playground
         run: ./scripts/build-web.sh

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -39,8 +39,41 @@ the templates, or the page itself.
   transitions, ...) are shown the way the CLI prints them.
 - **Generate**: the full C++ HFSM, optionally with the test bench,
   plus Mermaid / PlantUML / SCXML exports.
+- **Draw** it: the **Diagram** tab renders the machine as a UML state
+  chart and runs the simulator against it — fire events, watch the
+  active state move, step through guards and choice pseudostates.
+- **Edit** it: drag a part from the palette into a state, or use
+  **Add child...** from a state's context menu to fill in its
+  attributes as you create it; draw a transition between two states
+  with the handle on the source; move things around; edit a
+  Documentation block; delete a node and the transitions that hung
+  off it. Every committed change is written back into the model text
+  beside the diagram, so the two never disagree; press **Generate**
+  when you want the code to catch up.
 - **Take it away**: view any file, copy it, download one, or download
   all of them.
+
+### The same visualizer, not a second one
+
+The diagram is the *same* widget and simulator the WebGME editor runs,
+copied into the build verbatim. It reaches its model through
+`ModelBackend` and the surrounding application through
+`HostServices`, which is what lets it run with no WebGME at all:
+
+| | WebGME | playground |
+|---|---|---|
+| model | `WebGMEBackend` (client, territories, transactions) | `LocalBackend` (plain JSON, in memory) |
+| host UI | `WebGMEHost` (its context menu, part browser, document editor) | `web/host.js` (a menu, a mouse drag, a textarea) |
+| what changed | territory events | the difference after each committed transaction |
+
+The palette is derived from `src/common/meta.json`, the same
+generated metamodel that decides what `LocalBackend` will let you
+create — so a type added to the metamodel appears in the palette
+without anyone remembering to add it, and nothing is offered that
+would be refused on drop.
+
+Editing is in memory. Nothing is saved anywhere: the model text is
+the artifact, and it is yours to copy or download.
 
 Both panes are [CodeMirror](https://codemirror.net/5/) editors, so the
 model is edited with JSON highlighting and line numbers, and generated
@@ -51,15 +84,22 @@ plain text. Highlighting is strictly optional: if the editor library
 fails to load, the page falls back to a plain textarea and `<pre>` and
 generation still works.
 
-## What it does not do (yet)
+## What it does not do
 
-- **No editing or simulation.** Those live in the WebGME visualizer,
-  which is built on WebGME's client APIs (territories, transactions,
-  GME nodes). Bringing them across means decoupling the simulator
-  from those APIs — tracked with the Rust/WASM work.
 - **No persistence or collaboration.** Nothing leaves the browser;
   there is nowhere to save to. That is the trade for needing no
-  infrastructure.
+  infrastructure. Download the model (or copy it out of the editor)
+  to keep it.
+- **No undo.** WebGME's undo is a property of its commit history,
+  which is exactly the infrastructure this does without. Reload to
+  get back to the model you loaded.
+- **No editing an existing node's attributes** from the diagram. They
+  are set when the node is created (**Add child...**), and Documentation
+  has its own editor; after that, change them in the model text. In
+  WebGME this is the Property Editor's job, which is part of its
+  application rather than of the visualizer — so it is the next thing
+  the playground needs, not something that came across with the
+  widget.
 
 ## Why it cannot drift from the CLI
 
@@ -73,7 +113,9 @@ ids WebGME uses — so the browser runs the same
 `scripts/verify-web-build.js` enforces that in CI:
 
 1. every expected file is present in the build,
-2. the copied `src/common` modules are byte-identical to the sources,
+2. every copied source is byte-identical to the original — the whole
+   visualizer tree, markup and stylesheets included, with only the two
+   WebGME adapters allowed to be absent,
 3. `index.html` loads no remote assets (so it works offline),
 4. loading the generator **out of the build output** and regenerating
    every bundled example reproduces the committed goldens byte for

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -29,7 +29,8 @@ echo "building HFSM Playground -> $OUT"
 
 # 1. the page itself
 cp "$REPO_ROOT/web/index.html" "$REPO_ROOT/web/app.js" \
-   "$REPO_ROOT/web/app.css" "$REPO_ROOT/web/viz.js" "$OUT/"
+   "$REPO_ROOT/web/app.css" "$REPO_ROOT/web/viz.js" \
+   "$REPO_ROOT/web/host.js" "$REPO_ROOT/web/palette.js" "$OUT/"
 say "page"
 
 # 2. the generator: copied verbatim, never edited for the browser

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -54,7 +54,7 @@ function must(file) {
  'src/plugins/SoftwareGenerator/templates/uml/Templates.js',
  'src/plugins/SoftwareGenerator/templates/uml/static/magic_enum.hpp',
  // the visualizer and the contracts it runs on
- 'viz.js',
+ 'viz.js', 'host.js', 'palette.js',
  'src/common/viz/ModelBackend.js', 'src/common/viz/HostServices.js',
  'src/common/viz/LocalBackend.js', 'src/common/viz/describe.js',
  'src/visualizers/widgets/HFSMViz/HFSMVizWidget.js',

--- a/src/common/viz/LocalBackend.js
+++ b/src/common/viz/LocalBackend.js
@@ -88,6 +88,14 @@ define(['./ModelBackend', '../metaRules'], function (ModelBackend, metaRules) {
   };
 
   LocalBackend.prototype.getNodeInfo = function (id) {
+    // An id is a string. Anything else is a caller's mistake, and
+    // answering it anyway is how a node once ended up with an ARRAY
+    // for its type: `objects[['State']]` and `TYPES[['State']]` both
+    // coerce to the string and find something, and `['State'] ==
+    // 'State'` then passes every check downstream. Cytoscape's
+    // stylesheet, which compares exactly, was the only thing that
+    // noticed.
+    if (typeof id !== 'string') return null;
     var obj = this._objects()[id];
     if (obj) {
       return {

--- a/src/common/viz/LocalBackend.js
+++ b/src/common/viz/LocalBackend.js
@@ -89,15 +89,27 @@ define(['./ModelBackend', '../metaRules'], function (ModelBackend, metaRules) {
 
   LocalBackend.prototype.getNodeInfo = function (id) {
     var obj = this._objects()[id];
-    if (!obj) return null;
-    return {
-      id: id,
-      name: obj.name,
-      type: obj.type,
-      // a local store has no separate type identity: the name IS the
-      // type, and getValidChildTypes maps onto the same token
-      typeId: obj.type,
-    };
+    if (obj) {
+      return {
+        id: id,
+        name: obj.name,
+        type: obj.type,
+        // a local store has no separate type identity: the name IS the
+        // type, and getValidChildTypes maps onto the same token
+        typeId: obj.type,
+      };
+    }
+    // Not an object in the model, so it may be a PALETTE entry, which
+    // names a type rather than an instance. WebGME answers this from
+    // the meta node, which has an id of its own; here the type name is
+    // the whole identity. The widget deliberately asks the backend
+    // instead of resolving types itself (`_createNode`,
+    // `_canCreateChild`), which is what lets a host with a palette of
+    // its own work without knowing the metamodel.
+    if (TYPES[id] && !TYPES[id].isAbstract) {
+      return { id: id, name: id, type: id, typeId: id };
+    }
+    return null;
   };
 
   // how many children of each type `parentId` already has

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -10,12 +10,20 @@
  * in the playground, without either side keeping its own copy of the
  * rule.
  */
-define([], function () {
+define(['../metaRules'], function (metaRules) {
   'use strict';
 
   // a machine or a library is the top of a diagram; nothing draws
   // around it, so it must not report a parent to nest inside
   var ROOT_TYPES = ['State Machine', 'Library'];
+
+  // tracked for the simulator (event payload definitions) but never
+  // drawn in the graph
+  var NON_GRAPH_TYPES = ['Event', 'Field'];
+
+  // what a diagram can be dropped ONTO: a state, or the machine /
+  // library at the top of it
+  var CONTAINER_TYPES = ['State', 'State Machine', 'Library'];
 
   function isTransition(desc) {
     return desc.isConnection || desc.type === 'Internal Transition';
@@ -23,6 +31,43 @@ define([], function () {
 
   return {
     ROOT_TYPES: ROOT_TYPES,
+    NON_GRAPH_TYPES: NON_GRAPH_TYPES,
+
+    /**
+     * The types a palette may offer for dropping onto the diagram.
+     *
+     * Three things disqualify a type, and all three produce the same
+     * useless result -- a part that can be picked up and dropped and
+     * then is not there:
+     *
+     *  - it is not a child of anything the diagram draws INTO. Only
+     *    a state, a machine or a library is a container here, so a
+     *    Language (which nests only in another Language) has nowhere
+     *    to land.
+     *  - the graph does not draw it. An Event or a Field belongs to
+     *    the simulator's panels; dropped on the canvas it vanishes,
+     *    and a new Event is named "Event", which is a reserved name
+     *    the simulator warns about with a modal the moment it appears.
+     *  - it is the top of a diagram, or a connection. A machine is
+     *    what you are drawing IN, and a transition is drawn between
+     *    two states with the handle, not dropped onto one.
+     *
+     * Derived from the metamodel rather than listed, so a type added
+     * to meta.json shows up without anyone remembering to add it.
+     */
+    creatableTypes: function () {
+      var offered = {};
+      CONTAINER_TYPES.forEach(function (container) {
+        Object.keys(metaRules.childRules(container)).forEach(function (type) {
+          offered[type] = true;
+        });
+      });
+      return Object.keys(offered).filter(function (type) {
+        return !metaRules.isConnection(type) &&
+          NON_GRAPH_TYPES.indexOf(type) === -1 &&
+          ROOT_TYPES.indexOf(type) === -1;
+      }).sort();
+    },
 
     /**
      * @param desc  a descriptor from a ModelBackend, or null
@@ -31,6 +76,15 @@ define([], function () {
      */
     finish: function (desc) {
       if (!desc) return desc;
+
+      // An exported model wraps everything in a Project node. That is
+      // a container for the FILE, not part of any machine -- the
+      // metamodel does not describe it, and WebGME never feeds it
+      // because the visualizer opens on the machine itself. Drawn, it
+      // is a stray empty box floating beside the diagram. Anything
+      // else the metamodel has no rules for is dropped for the same
+      // reason: the graph has nothing to say about it.
+      if (!metaRules.types[desc.type]) return null;
 
       // a transition shows its trigger, not its name
       if (isTransition(desc)) {

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -10,6 +10,7 @@ define([
   "text!./HFSM.html",
   "./Dialog/Dialog",
   "hfsm/viz/HostServices",
+  "hfsm/viz/describe",
   "hfsm/viz/layoutInput",
   "./Simulator/Simulator",
   "./Simulator/Choice",
@@ -36,6 +37,7 @@ define([
     HFSMHtml,
     Dialog,
     HostServices,
+    describe,
     layoutInput,
     Simulator,
     Choice,
@@ -67,10 +69,15 @@ define([
     cytoscape.use( cyPanZoom, $ );
     cytoscape.use( coseBilkent );
 
-    var rootTypes = ["State Machine","Library"];
-    // types tracked for the simulator (event payload definitions) but
-    // never rendered in the state machine graph
-    var nonGraphTypes = ["Event", "Field"];
+    // Both lists live in `describe`, which is where the other rules
+    // about what the graph draws already are -- the palette needs the
+    // same answers, and three copies of them would eventually
+    // disagree.
+    var rootTypes = describe.ROOT_TYPES;
+    var nonGraphTypes = describe.NON_GRAPH_TYPES;
+
+    // how far apart to place parts dropped in the same gesture
+    var DROP_STAGGER = 20;
 
     var HFSMVizWidget,
         WIDGET_CLASS = "h-f-s-m-viz";
@@ -1234,6 +1241,34 @@ define([
       return gmePos;
     };
 
+    /**
+     * Whether a position out of the model should be written back onto
+     * a node that is already on the graph.
+     *
+     * Two reasons it should not, both of which made dragging one
+     * state disturb its neighbours -- and worse every time, since
+     * each drag saved the disturbed positions and fed them back in:
+     *
+     * A COMPOUND PARENT has no position of its own. Cytoscape derives
+     * it from the children, and setting it moves the entire subtree
+     * by the difference. Dragging a child changes its parent's
+     * derived position, that gets saved, and putting it back shifts
+     * every sibling.
+     *
+     * A position that MATCHES where the node already is means the
+     * model is only telling us what we did. Comparing against the
+     * previous descriptor instead is not the same question, and it
+     * is not free to answer wrongly: the value is converted through
+     * the node's current width and height, which change as a
+     * container's contents move.
+     */
+    HFSMVizWidget.prototype.shouldApplyPosition = function(cyNode, desc) {
+      var self = this;
+      if (!desc.position || cyNode.isParent())
+        return false;
+      return self.needToUpdatePosition(self.cyPosition(cyNode), desc.position);
+    };
+
     HFSMVizWidget.prototype.needToUpdatePosition = function(pos1, pos2) {
       var dx = Math.abs(pos1.x - pos2.x);
       var dy = Math.abs(pos1.y - pos2.y);
@@ -1602,11 +1637,10 @@ define([
             cyNode.data( this.getDescData(desc) );
             // update position from model
             if (!_.isEqual(oldDesc.position, desc.position)) {
-              //console.log(`${desc.name}: (old, new)`);
-              //console.log(oldDesc.position);
-              //console.log(desc.position);
               if (rootTypes.indexOf(desc.type) == -1) {
-                self.cyPosition(cyNode, self.gmePosToCyPos(desc));
+                if (self.shouldApplyPosition(cyNode, desc)) {
+                  self.cyPosition(cyNode, self.gmePosToCyPos(desc));
+                }
                 delete this._unsavedNodePositions[desc.id];
               }
             }
@@ -1850,36 +1884,58 @@ define([
       return canCreate;
     };
 
-    HFSMVizWidget.prototype._createNode = function( baseId, parentId, childPosition ) {
+    /**
+     * Create one child per dragged item.
+     *
+     * A drag carries a LIST -- that is what `dragInfo.items` is --
+     * and this used to hand the whole array to the backend as though
+     * it were a single id. Nothing complained: JavaScript compares
+     * `["State"] == "State"` as true, so every type check downstream
+     * passed and the node was created with an ARRAY for its type.
+     * Cytoscape's stylesheet matches data exactly, so
+     * `node[NodeType = "Choice Pseudostate"]` did not match it and
+     * every dropped part fell back to the default shape -- a state
+     * looked right by luck, a pseudostate looked like a state.
+     */
+    HFSMVizWidget.prototype._createNode = function( baseIds, parentId, childPosition ) {
       var self = this;
+      var items = _.isArray(baseIds) ? baseIds : (baseIds ? [baseIds] : []);
+      if (!items.length)
+        return;
 
-      if (baseId) {
-        var selector = gmeIdToCySelector(parentId),
-            cyNode = self._cy.$(selector);
-        self.forceShowChildren( cyNode.id() );
-        var pos = self.screenPosToCyPos( childPosition );
+      var selector = gmeIdToCySelector(parentId),
+          cyNode = self._cy.$(selector);
+      self.forceShowChildren( cyNode.id() );
+      var pos = self.screenPosToCyPos( childPosition );
 
-        // captured inside the body so the completion callback sees
-        // it even if a backend settles synchronously
-        var newChildPath = null;
-        self._backend.transact("Creating new child", function () {
-          // baseId here is a palette entry: ask the backend what it
-          // is, so the widget never resolves meta types itself
+      // captured inside the body so the completion callback sees
+      // them even if a backend settles synchronously
+      var newChildPaths = [];
+      self._backend.transact("Creating new child", function () {
+        items.forEach(function (baseId, index) {
+          // a palette entry: ask the backend what it is, so the
+          // widget never resolves meta types itself
           var info = self._backend.getNodeInfo(baseId);
-          newChildPath = self._backend.createChild(parentId, info && info.type,
-                                                   { position: pos });
-          return newChildPath;
-        }, function (err) {
-          // don't select a node the store rejected
-          if (err) {
-            console.error("Could not create child: ", err);
+          if (!info || !info.type)
             return;
-          }
-          if (newChildPath) {
-            self._backend.setActiveSelection([newChildPath], self);
-          }
+          // dropped together, so stagger them rather than stacking
+          // every one on the same point
+          var at = { x: pos.x + index * DROP_STAGGER,
+                     y: pos.y + index * DROP_STAGGER };
+          newChildPaths.push(
+            self._backend.createChild(parentId, info.type, { position: at }));
         });
-      }
+        return newChildPaths;
+      }, function (err) {
+        // don't select nodes the store rejected
+        if (err) {
+          console.error("Could not create child: ", err);
+          return;
+        }
+        if (newChildPaths.length) {
+          self._backend.setActiveSelection(newChildPaths, self);
+        }
+      });
     };
 
     HFSMVizWidget.prototype._instanceNodes = function( nodeIds, parentId, childPosition ) {

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -123,25 +123,30 @@ define([
       this._logger.debug("ctor finished");
     };
 
+    /**
+     * The inverse of `_getContainerPosFromEvent`: a position measured
+     * inside this widget, expressed as a page coordinate.
+     *
+     * This had the same WebGME-only reckoning that one did -- adding
+     * the offsets of `.panel-base-wh` and `.ui-layout-pane-center`.
+     * Those selectors match nothing in another host, so `.position()`
+     * returned undefined and reading `.left` threw. Its one caller is
+     * the menu that asks which kind of transition to draw, and it is
+     * called from inside an edgehandles callback, so the throw was
+     * swallowed: releasing a transition onto a state simply did
+     * nothing at all outside WebGME.
+     */
     HFSMVizWidget.prototype._relativeToWindowPos = function( relativePos ) {
       var self = this;
-
-      var windowPos = {
-        x: relativePos.x,
-        y: relativePos.y
+      var node = self._container && self._container[0];
+      if (!node) {
+        return { x: relativePos.x, y: relativePos.y };
+      }
+      var rect = node.getBoundingClientRect();
+      return {
+        x: relativePos.x + rect.left + window.pageXOffset,
+        y: relativePos.y + rect.top + window.pageYOffset,
       };
-
-      var splitPos = $(self._container).parents(".panel-base-wh").parent().position();
-      var centerPanelPos = $(".ui-layout-pane-center").position();
-      // X OFFSET
-      windowPos.x += splitPos.left;
-      windowPos.x += centerPanelPos.left;
-
-      // Y OFFSET
-      windowPos.y += splitPos.top;
-      windowPos.y += centerPanelPos.top;
-
-      return windowPos;
     };
 
     /**
@@ -2104,11 +2109,17 @@ define([
         out: function (/*event, dragInfo*/) {
           self._isDropping = false;
           self._dropInfo = null;
+          // nothing is being dropped any more, so the "you can drop
+          // here" highlight is stale. It used to be left for the next
+          // hover event to clear, which never comes if the pointer
+          // stops moving -- the state stayed lit until you nudged it.
+          self.clearDropStatus();
         },
         drop: function (event, dragInfo) {
           self.handleDrop(event, dragInfo);
           self._isDropping = false;
           self._dropInfo = null;
+          self.clearDropStatus();
         }
       });
     };

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -1,0 +1,178 @@
+'use strict';
+
+/**
+ * Editing in the playground.
+ *
+ * The palette hands the widget a TYPE NAME and nothing else; the
+ * widget hands that to `backend.getNodeInfo` and creates whatever
+ * comes back. That handover is the whole contract between the two,
+ * and it is the part that can silently rot -- a type the palette
+ * offers but the backend will not resolve produces a drag that lands
+ * and does nothing, with no error anywhere.
+ *
+ * The DOM half (menus, the drag itself) is verified in a browser: a
+ * fake DOM here could only confirm that the fake behaves like the
+ * fake.
+ */
+
+var assert = require('assert');
+var path = require('path');
+
+var repoRoot = path.resolve(__dirname, '..');
+
+function playgroundContext(name) {
+  var requirejs = require('requirejs');
+  return requirejs.config({
+    context: name,
+    baseUrl: repoRoot,
+    nodeRequire: require,
+    paths: {
+      hfsm: path.join(repoRoot, 'src/common'),
+      // vendored in the build; see test/stubs/jquery.js
+      jquery: 'test/stubs/jquery',
+      // the page loads these as siblings of viz.js
+      host: 'web/host',
+      palette: 'web/palette',
+    },
+  });
+}
+
+function load(name, ids) {
+  var req = playgroundContext(name);
+  return new Promise(function (resolve, reject) {
+    req(ids, function () {
+      resolve(Array.prototype.slice.call(arguments));
+    }, reject);
+  });
+}
+
+describe('playground editing', function () {
+
+  var mods = {};
+
+  before(function () {
+    this.timeout(10000);
+    return load('playground-editing', [
+      'palette', 'host',
+      'hfsm/metaRules', 'hfsm/viz/LocalBackend', 'hfsm/resolveModel',
+    ]).then(function (loaded) {
+      mods.palette = loaded[0];
+      mods.PlaygroundHost = loaded[1];
+      mods.metaRules = loaded[2];
+      mods.LocalBackend = loaded[3];
+      mods.resolveModel = loaded[4];
+    });
+  });
+
+  describe('the palette', function () {
+
+    it('offers every type the metamodel can instantiate', function () {
+      var offered = mods.palette.creatableTypes();
+      mods.metaRules.concreteTypes().forEach(function (type) {
+        if (mods.metaRules.isConnection(type)) return;
+        assert.ok(offered.indexOf(type) > -1,
+                  type + ' can be created but is not in the palette');
+      });
+    });
+
+    it('offers nothing abstract', function () {
+      // dragging one in would produce a node of a type that cannot
+      // exist, and the resolver would reject the model afterwards
+      mods.palette.creatableTypes().forEach(function (type) {
+        assert.ok(!mods.metaRules.isAbstract(type),
+                  type + ' is abstract and cannot be instantiated');
+      });
+    });
+
+    it('leaves the transitions out, since those are drawn', function () {
+      // a transition needs two endpoints, so it is made with the edge
+      // handle; offering it here would only produce refused drops
+      var offered = mods.palette.creatableTypes();
+      assert.ok(offered.indexOf('External Transition') === -1);
+      assert.ok(offered.indexOf('Local Transition') === -1);
+      assert.ok(offered.indexOf('Internal Transition') > -1,
+                'an internal transition IS a child, not a connection');
+    });
+  });
+
+  describe('the host', function () {
+    it('satisfies the whole HostServices contract', function () {
+      // the factory asserts this itself, so a missing method throws
+      // here rather than the first time someone right-clicks
+      var host = mods.PlaygroundHost();
+      ['contextMenu', 'editDocument', 'makeDroppable'].forEach(function (m) {
+        assert.strictEqual(typeof host[m], 'function', m + ' is missing');
+      });
+    });
+  });
+
+  describe('what the palette hands over', function () {
+
+    function machine() {
+      var model = {
+        root: '/p',
+        objects: {
+          '/p': { name: 'P', type: 'Project' },
+          '/p/m': { name: 'M', type: 'State Machine' },
+          '/p/m/i': { name: 'Initial', type: 'Initial' },
+          '/p/m/A': { name: 'A', type: 'State' },
+          '/p/m/ti': {
+            name: 'ti', type: 'External Transition',
+            pointers: { src: '/p/m/i', dst: '/p/m/A' },
+          },
+        },
+      };
+      mods.resolveModel.resolve(model);
+      return mods.LocalBackend(model);
+    }
+
+    it('resolves a type name the way the widget asks it to', function () {
+      // `_canCreateChild` accepts when
+      // getValidChildTypes(parent)[info.type] === info.typeId
+      var backend = machine();
+      var allowed = backend.getValidChildTypes('/p/m');
+      mods.palette.creatableTypes().forEach(function (type) {
+        var info = backend.getNodeInfo(type);
+        assert.ok(info, 'the backend cannot resolve palette entry ' + type);
+        assert.strictEqual(info.type, type);
+        if (allowed[type]) {
+          assert.strictEqual(allowed[type], info.typeId,
+                             type + ' would be refused by the widget');
+        }
+      });
+    });
+
+    it('creates the type that was dragged', function () {
+      var backend = machine();
+      var created = null;
+      backend.transact('drop', function () {
+        var info = backend.getNodeInfo('State');   // what the widget does
+        created = backend.createChild('/p/m', info.type, { position: { x: 5, y: 6 } });
+      });
+      var node = backend.getNodeInfo(created);
+      assert.strictEqual(node.type, 'State');
+    });
+
+    it('answers for a type name only where no object has that id', function () {
+      // an object always wins: a model is free to contain a node
+      // whose path happens to read like a type name
+      var backend = machine();
+      assert.strictEqual(backend.getNodeInfo('/p/m/A').type, 'State');
+      assert.strictEqual(backend.getNodeInfo('/p/m/A').id, '/p/m/A');
+    });
+
+    it('refuses a name that is not a concrete type', function () {
+      var backend = machine();
+      assert.strictEqual(backend.getNodeInfo('Not A Type'), null);
+      // abstract types are in the metamodel but cannot be created
+      var abstractTypes = Object.keys(mods.metaRules.types).filter(function (t) {
+        return mods.metaRules.isAbstract(t);
+      });
+      assert.ok(abstractTypes.length, 'expected the metamodel to have some');
+      abstractTypes.forEach(function (type) {
+        assert.strictEqual(backend.getNodeInfo(type), null,
+                           type + ' is abstract and must not resolve');
+      });
+    });
+  });
+});

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -55,24 +55,34 @@ describe('playground editing', function () {
     return load('playground-editing', [
       'palette', 'host',
       'hfsm/metaRules', 'hfsm/viz/LocalBackend', 'hfsm/resolveModel',
+      'hfsm/viz/describe', 'hfsm/checkModel',
     ]).then(function (loaded) {
       mods.palette = loaded[0];
       mods.PlaygroundHost = loaded[1];
       mods.metaRules = loaded[2];
       mods.LocalBackend = loaded[3];
       mods.resolveModel = loaded[4];
+      mods.describe = loaded[5];
+      mods.checkModel = loaded[6];
     });
   });
 
   describe('the palette', function () {
 
-    it('offers every type the metamodel can instantiate', function () {
-      var offered = mods.palette.creatableTypes();
-      mods.metaRules.concreteTypes().forEach(function (type) {
-        if (mods.metaRules.isConnection(type)) return;
-        assert.ok(offered.indexOf(type) > -1,
-                  type + ' can be created but is not in the palette');
-      });
+    it('offers exactly what can be drawn inside a state', function () {
+      // Anything else is a part that can be picked up and dropped and
+      // then is not there -- see describe.creatableTypes for why each
+      // kind of exclusion matters.
+      assert.deepStrictEqual(mods.palette.creatableTypes(), [
+        'Choice Pseudostate',
+        'Deep History Pseudostate',
+        'Documentation',
+        'End State',
+        'Initial',
+        'Internal Transition',
+        'Shallow History Pseudostate',
+        'State',
+      ]);
     });
 
     it('offers nothing abstract', function () {
@@ -92,6 +102,76 @@ describe('playground editing', function () {
       assert.ok(offered.indexOf('Local Transition') === -1);
       assert.ok(offered.indexOf('Internal Transition') > -1,
                 'an internal transition IS a child, not a connection');
+    });
+
+    it('leaves out what the graph does not draw', function () {
+      // An Event or a Field belongs to the simulator's panels, not to
+      // the canvas: dropped on the diagram it simply vanishes. Worse,
+      // a new Event is named "Event", which is a reserved name -- the
+      // simulator then warns about it with a MODAL, on every refresh,
+      // and the page cannot be used until it is dismissed.
+      var offered = mods.palette.creatableTypes();
+      mods.describe.NON_GRAPH_TYPES.forEach(function (type) {
+        assert.ok(offered.indexOf(type) === -1,
+                  type + ' is not drawn and must not be offered');
+      });
+      assert.strictEqual(mods.checkModel.isValidString('Event'), false,
+                         'the reason Event is dangerous: the default ' +
+                         'name a new one gets is reserved');
+    });
+
+    it('leaves out what has nowhere to land', function () {
+      // The diagram draws INTO a state, a machine or a library. A
+      // Language nests only inside another Language, and a machine or
+      // a library is the thing being drawn rather than something to
+      // drop into it.
+      var offered = mods.palette.creatableTypes();
+      ['Language', 'Library', 'State Machine'].forEach(function (type) {
+        assert.ok(offered.indexOf(type) === -1,
+                  type + ' cannot be a child of anything drawable');
+      });
+    });
+
+    it('offers only what a state or a machine will actually accept',
+       function () {
+         // the drop is validated against the metamodel, so anything
+         // offered that no container allows is a guaranteed refusal
+         var containers = ['State', 'State Machine', 'Library'];
+         mods.palette.creatableTypes().forEach(function (type) {
+           var fits = containers.some(function (c) {
+             return !!mods.metaRules.childRules(c)[type];
+           });
+           assert.ok(fits, type + ' is offered but nothing can contain it');
+         });
+       });
+  });
+
+  describe('what the diagram draws', function () {
+
+    it('drops the Project wrapper an export puts around the model',
+       function () {
+         // it is a container for the file, not part of the machine:
+         // WebGME never feeds it, because the visualizer opens on the
+         // machine itself, so drawing it is a stray empty box beside
+         // the diagram
+         assert.strictEqual(
+           mods.describe.finish({ id: '/p', name: 'FixtureProject',
+                                  type: 'Project' }),
+           null);
+       });
+
+    it('keeps everything the metamodel does describe', function () {
+      Object.keys(mods.metaRules.types).forEach(function (type) {
+        var desc = mods.describe.finish({ id: '/x', name: 'n', type: type });
+        assert.ok(desc, type + ' is in the metamodel and must be kept');
+      });
+    });
+
+    it('still gives a machine no parent to nest inside', function () {
+      var desc = mods.describe.finish({ id: '/p/m', name: 'M',
+                                        type: 'State Machine',
+                                        parentId: '/p' });
+      assert.strictEqual(desc.parentId, null);
     });
   });
 
@@ -159,6 +239,20 @@ describe('playground editing', function () {
       var backend = machine();
       assert.strictEqual(backend.getNodeInfo('/p/m/A').type, 'State');
       assert.strictEqual(backend.getNodeInfo('/p/m/A').id, '/p/m/A');
+    });
+
+    it('refuses an id that is not a string', function () {
+      // The drag carries a LIST of items, and handing the whole list
+      // over as one id used to "work": every lookup coerced it to a
+      // string and every `==` comparison passed, so the node was
+      // created with an array for its type and drew with the wrong
+      // shape. Answering only for strings makes that a refusal
+      // instead of a wrong answer.
+      var backend = machine();
+      [['State'], ['/p/m/A'], null, undefined, 42, {}].forEach(function (bad) {
+        assert.strictEqual(backend.getNodeInfo(bad), null,
+                           JSON.stringify(bad) + ' is not an id');
+      });
     });
 
     it('refuses a name that is not a concrete type', function () {

--- a/test/stubs/jquery.js
+++ b/test/stubs/jquery.js
@@ -1,0 +1,32 @@
+/**
+ * jQuery, stubbed for node.
+ *
+ * The playground's host and palette are jQuery-based because the
+ * widget they serve is. jQuery is a vendored browser library, so
+ * whether it happens to be installed here says nothing about the
+ * questions these tests ask -- which types the palette offers, and
+ * whether the host satisfies the HostServices contract. Both are
+ * answered before a single element is touched.
+ *
+ * Anything that really does reach the DOM is verified in a browser
+ * instead; a fake that returned plausible-looking elements would only
+ * be able to confirm that the fake behaves like the fake.
+ */
+define([], function () {
+  'use strict';
+
+  function chain() {
+    var self = function () { return self; };
+    ['append', 'appendTo', 'text', 'attr', 'css', 'val', 'on', 'off',
+     'remove', 'focus', 'filter', 'find'].forEach(function (method) {
+       self[method] = function () { return self; };
+     });
+    self.length = 0;
+    self[0] = undefined;
+    return self;
+  }
+
+  var $ = function () { return chain(); };
+  $.fn = {};
+  return $;
+});

--- a/web/app.css
+++ b/web/app.css
@@ -402,3 +402,122 @@ select:focus-visible,
     overflow: hidden;
 }
 .viewdiagram[hidden] { display: none; }
+
+/* ---- editing: palette, menu, drag ghost ------------------------ */
+
+/* The diagram view is a palette strip above the widget. The widget
+   draws into an absolutely positioned element that fills its
+   container, so it gets a container to itself rather than sharing
+   one with the strip. */
+.viewdiagram { display: flex; flex-direction: column; }
+.viz-host { flex: 1 1 auto; position: relative; min-height: 0; }
+
+.viz-palette {
+    flex: 0 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    border-bottom: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.viz-palette-label { font-size: 11px; color: #57606a; margin-right: 4px; }
+.viz-part {
+    font: inherit;
+    font-size: 11px;
+    line-height: 1;
+    padding: 4px 8px;
+    border: 1px solid #d0d7de;
+    border-radius: 12px;
+    background: #fff;
+    cursor: grab;
+    /* the drag is ours, so the browser's own must not also start */
+    user-select: none;
+    -webkit-user-select: none;
+}
+.viz-part:hover { border-color: #0969da; color: #0969da; }
+.viz-part:active { cursor: grabbing; }
+
+/* Follows the pointer during a drag. `pointer-events: none` is not
+   cosmetic: with the ghost under the cursor, cytoscape's container
+   would stop receiving mousemove and the widget would never learn
+   which state the part is over. */
+.pg-drag-ghost {
+    position: absolute;
+    z-index: 10000;
+    pointer-events: none;
+    font-size: 11px;
+    padding: 3px 7px;
+    border: 1px solid #0969da;
+    border-radius: 12px;
+    background: #ddf4ff;
+    color: #0969da;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+}
+
+.pg-menu {
+    position: absolute;
+    z-index: 10001;
+    margin: 0;
+    padding: 4px 0;
+    list-style: none;
+    min-width: 160px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #fff;
+    box-shadow: 0 8px 24px rgba(140, 149, 159, .2);
+    font-size: 12px;
+}
+.pg-menu li { padding: 5px 12px; cursor: pointer; }
+.pg-menu li:hover, .pg-menu li:focus { background: #0969da; color: #fff; outline: none; }
+
+/* The documentation editor. WebGME opens a rich-text dialog here;
+   the attribute is text either way. */
+.pg-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10002;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(27, 31, 36, .5);
+}
+.pg-dialog {
+    width: min(720px, 90vw);
+    background: #fff;
+    border-radius: 6px;
+    padding: 16px;
+    box-shadow: 0 8px 24px rgba(66, 74, 83, .32);
+}
+.pg-dialog h3 { margin: 0 0 8px; font-size: 14px; }
+.pg-doc {
+    width: 100%;
+    height: 40vh;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    padding: 8px;
+    resize: vertical;
+}
+.pg-dialog-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 12px;
+}
+.pg-dialog-buttons button {
+    font: inherit;
+    font-size: 12px;
+    padding: 5px 12px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #f6f8fa;
+    cursor: pointer;
+}
+.pg-dialog-buttons button.primary {
+    background: #1f883d;
+    border-color: #1f883d;
+    color: #fff;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -470,6 +470,22 @@
     if (diagram) refreshDiagram();
   }
 
+  // The diagram is an editor too: dropping a part in, drawing a
+  // transition, renaming a state -- all of it changes the model the
+  // graph is running on. The text beside it has to say the same
+  // thing, so it is rewritten after every committed change rather
+  // than waiting to be asked. Generation is NOT re-run: it is the
+  // slow half, and the user says when.
+  function diagramEdited() {
+    if (!vizModule || !vizModule.current()) return;
+    var text = vizModule.currentModelJSON();
+    if (!text) return;
+    setModelText(text);
+    vizModelText = text.trim();   // the diagram already matches it
+    showDiagnostics([]);
+    setStatus('model edited \u00b7 press Generate', 'warn');
+  }
+
   // Take the diagram down. A machine left on screen next to an error
   // message reads as though the error were about what is drawn, and
   // it leaves `Save layout` pointing at a model the text no longer
@@ -512,6 +528,7 @@
     if (!quiet) setStatus('drawing...');
     requirejs(['viz'], function (viz) {
       vizModule = viz;
+      viz.onModelEdited(diagramEdited);
       try {
         viz.mount(el('viewDiagram'), model);
         vizModelText = raw;

--- a/web/app.js
+++ b/web/app.js
@@ -478,6 +478,23 @@
   // slow half, and the user says when.
   function diagramEdited() {
     if (!vizModule || !vizModule.current()) return;
+
+    // The editor and the diagram are both live, so the text can have
+    // moved on since the diagram was drawn from it. Writing the
+    // diagram's model over it would silently throw the typing away --
+    // the same conflict `saveLayout` refuses, and it has to be
+    // refused here too, where it arrives without anyone asking for
+    // it. Typing wins: it is the harder of the two to do again.
+    if (getModelText().trim() !== vizModelText) {
+      showDiagnostics(['The diagram changed, but the model text has been ' +
+                       'edited since the diagram was drawn, so the text was ' +
+                       'left alone. Press Generate to redraw the diagram from ' +
+                       'the text -- which discards the change just made to ' +
+                       'the diagram.'], 'warn');
+      setStatus('diagram and text disagree', 'warn');
+      return;
+    }
+
     var text = vizModule.currentModelJSON();
     if (!text) return;
     setModelText(text);

--- a/web/host.js
+++ b/web/host.js
@@ -55,14 +55,44 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     self.closeMenu();
 
     var menu = $('<ul class="pg-menu" role="menu"></ul>');
+
+    function choose(key, event) {
+      if (event) event.stopPropagation();
+      self.closeMenu();
+      if (onSelect) onSelect(key);
+    }
+
+    // Arrow keys move between items and wrap, which is what `role
+    //="menu"` tells a screen reader to expect. Without it the items
+    // are reachable by Tab, which walks straight out of the menu and
+    // on through the page behind it.
+    function moveFocus(from, delta) {
+      var items = menu.children();
+      var at = items.index(from);
+      var next = items.get((at + delta + items.length) % items.length);
+      if (next) next.focus();
+    }
+
     Object.keys(items || {}).forEach(function (key) {
       var item = items[key] || {};
       $('<li role="menuitem" tabindex="0"></li>')
         .text(item.name === undefined ? key : item.name)
-        .on('click', function (event) {
-          event.stopPropagation();
-          self.closeMenu();
-          if (onSelect) onSelect(key);
+        .on('click', function (event) { choose(key, event); })
+        // An item that can be focused but not activated from the
+        // keyboard is a trap: it takes the focus and then does
+        // nothing with it.
+        .on('keydown', function (event) {
+          if (event.key === 'Enter' || event.key === ' ' ||
+              event.key === 'Spacebar') {          // Spacebar: older Edge
+            event.preventDefault();                // or Space scrolls the page
+            choose(key, event);
+          } else if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            moveFocus(this, 1);
+          } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            moveFocus(this, -1);
+          }
         })
         .appendTo(menu);
     });
@@ -92,6 +122,12 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     setTimeout(function () {
       $(document).on('mousedown', dismiss).on('keydown', dismiss);
     }, 0);
+
+    // Somewhere to start from. Without this the keyboard has no way
+    // into a menu that was opened by a right-click, since the focus
+    // is still wherever it was.
+    var first = menu.children().get(0);
+    if (first) first.focus();
   };
 
   /* -------------------- documentation editor ------------------- */

--- a/web/host.js
+++ b/web/host.js
@@ -33,15 +33,22 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     this._targets = [];      // { el, handlers }
     this._drag = null;
     this._menu = null;
+    // Everything a menu or a dialog puts OUTSIDE its own element --
+    // document handlers, pending timers -- so tearing the host down
+    // can reach it. Removing the element is not enough: the handlers
+    // outlive it, and after a remount they act on a widget and a
+    // backend that are gone.
+    this._closeMenu = null;
+    this._closeDialog = null;
   }
 
   /* ----------------------- context menu ----------------------- */
 
   PlaygroundHost.prototype.closeMenu = function () {
-    if (this._menu) {
-      $(this._menu).remove();
-      this._menu = null;
-    }
+    var close = this._closeMenu;
+    this._closeMenu = null;
+    this._menu = null;
+    if (close) close();
   };
 
   /**
@@ -126,12 +133,17 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
         return;
       }
       self.closeMenu();
-      $(document).off('mousedown', dismiss).off('keydown', dismiss);
     };
     // next tick: the click that opened this must not also close it
-    setTimeout(function () {
+    var armed = setTimeout(function () {
       $(document).on('mousedown', dismiss).on('keydown', dismiss);
     }, 0);
+
+    self._closeMenu = function () {
+      clearTimeout(armed);   // may not have been armed yet
+      $(document).off('mousedown', dismiss).off('keydown', dismiss);
+      menu.remove();
+    };
 
     // Somewhere to start from. Without this the keyboard has no way
     // into a menu that was opened by a right-click, since the focus
@@ -148,6 +160,9 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
    * widget only cares that it gets the new value back.
    */
   PlaygroundHost.prototype.editDocument = function (text, onSave) {
+    var self = this;
+    self.closeDialog();          // never two at once
+
     var overlay = $('<div class="pg-overlay"></div>');
     var box = $('<div class="pg-dialog" role="dialog" aria-modal="true" ' +
                 'aria-label="Edit documentation"></div>');
@@ -157,12 +172,46 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     var cancel = $('<button type="button">Cancel</button>');
     var save = $('<button type="button" class="primary">Save</button>');
 
+    // whatever had the focus before, to give it back on close
+    var opener = document.activeElement;
+
     function close() {
-      overlay.remove();
-      $(document).off('keydown', onKey);
+      self.closeDialog();
+    }
+
+    /**
+     * Keep Tab inside the dialog.
+     *
+     * `aria-modal="true"` promises that nothing behind the overlay
+     * can be reached; without this, Tab walks straight out of it and
+     * into the page underneath, where the controls are still
+     * operable and invisible behind the backdrop.
+     */
+    function focusables() {
+      return box.find('textarea, button').filter(function () {
+        return !this.disabled;
+      });
     }
     function onKey(event) {
-      if (event.key === 'Escape') close();
+      if (event.key === 'Escape') {
+        close();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      var items = focusables();
+      if (!items.length) return;
+      var first = items.get(0), last = items.get(items.length - 1);
+      // wrap at each end rather than letting the browser leave
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!box[0].contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
     }
 
     cancel.on('click', close);
@@ -182,6 +231,23 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     $(document.body).append(overlay);
     $(document).on('keydown', onKey);
     area.focus();
+
+    self._closeDialog = function () {
+      $(document).off('keydown', onKey);
+      overlay.remove();
+      // put the focus back where it came from, or it lands on
+      // <body> and the keyboard has lost its place in the page
+      if (opener && opener.focus && document.contains(opener)) {
+        opener.focus();
+      }
+    };
+  };
+
+  /** close the documentation editor if one is open */
+  PlaygroundHost.prototype.closeDialog = function () {
+    var close = this._closeDialog;
+    this._closeDialog = null;
+    if (close) close();
   };
 
   /* ------------------------ drag and drop ---------------------- */
@@ -273,10 +339,15 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     });
   };
 
-  /** tear down anything still on screen */
+  /**
+   * Tear down anything still on screen, and everything it attached
+   * elsewhere. A host outlives neither its widget nor its backend, so
+   * a handler left on `document` would fire into a torn-down one.
+   */
   PlaygroundHost.prototype.destroy = function () {
     this._endDrag();
     this.closeMenu();
+    this.closeDialog();
     this._targets = [];
   };
 

--- a/web/host.js
+++ b/web/host.js
@@ -112,9 +112,19 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     if (overflowX > 0) menu.css('left', Math.max(0, parseFloat(menu.css('left')) - overflowX - 4));
     if (overflowY > 0) menu.css('top', Math.max(0, parseFloat(menu.css('top')) - overflowY - 4));
 
-    // dismissed by clicking away or by Escape, like any other menu
+    // Dismissed by clicking AWAY, or by Escape.
+    //
+    // "Away" has to be checked: this listens on mousedown, which
+    // happens BEFORE the item's own click. Without the containment
+    // test, pressing the mouse over an item tore the menu down and
+    // the click then landed on nothing -- so choosing which kind of
+    // transition to draw appeared to do nothing at all.
     var dismiss = function (event) {
       if (event.type === 'keydown' && event.key !== 'Escape') return;
+      if (event.type === 'mousedown' && self._menu &&
+          self._menu.contains(event.target)) {
+        return;
+      }
       self.closeMenu();
       $(document).off('mousedown', dismiss).off('keydown', dismiss);
     };

--- a/web/host.js
+++ b/web/host.js
@@ -1,0 +1,240 @@
+/**
+ * HostServices over plain DOM -- the playground's counterpart to
+ * WebGMEHost.
+ *
+ * The widget needs three things from whatever application it is
+ * embedded in: somewhere to pop a context menu, somewhere to edit a
+ * block of documentation, and a way to receive items dragged from a
+ * palette. WebGME answers all three with its own UI framework. This
+ * answers them with a menu, an overlay and a mouse-drag, which is all
+ * they ever were.
+ *
+ * WHY THE DRAG IS NOT HTML5 DRAG AND DROP
+ * ---------------------------------------
+ * During an HTML5 drag the browser stops delivering mousemove and
+ * mouseover: only the drag events fire. Cytoscape learns which node
+ * the pointer is over from ordinary mouse events, and the widget
+ * takes the drop's parent from that (`_hoveredNodeId`) -- so with
+ * HTML5 dragging, every drop would land with no parent and be
+ * rejected. jQuery UI, which WebGME drags with, is mouse-based for
+ * the same reason.
+ *
+ * See src/common/viz/HostServices.js for the contract.
+ */
+define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
+  'use strict';
+
+  function elementOf(target) {
+    if (!target) return null;
+    return target.jquery ? target[0] : target;
+  }
+
+  function PlaygroundHost() {
+    this._targets = [];      // { el, handlers }
+    this._drag = null;
+    this._menu = null;
+  }
+
+  /* ----------------------- context menu ----------------------- */
+
+  PlaygroundHost.prototype.closeMenu = function () {
+    if (this._menu) {
+      $(this._menu).remove();
+      this._menu = null;
+    }
+  };
+
+  /**
+   * @param items     { key: { name, icon } } -- insertion order is
+   *                  display order, as the contract says
+   * @param onSelect  called with the chosen key
+   * @param position  { x, y } in PAGE coordinates
+   */
+  PlaygroundHost.prototype.contextMenu = function (items, onSelect, position) {
+    var self = this;
+    self.closeMenu();
+
+    var menu = $('<ul class="pg-menu" role="menu"></ul>');
+    Object.keys(items || {}).forEach(function (key) {
+      var item = items[key] || {};
+      $('<li role="menuitem" tabindex="0"></li>')
+        .text(item.name === undefined ? key : item.name)
+        .on('click', function (event) {
+          event.stopPropagation();
+          self.closeMenu();
+          if (onSelect) onSelect(key);
+        })
+        .appendTo(menu);
+    });
+    if (!menu.children().length) return;   // nothing to offer
+
+    menu.css({ left: (position && position.x) || 0,
+               top: (position && position.y) || 0 });
+    $(document.body).append(menu);
+    self._menu = menu[0];
+
+    // Keep the menu on screen: it is placed at the pointer, which
+    // near the right or bottom edge would otherwise put half of it
+    // outside the window with no way to scroll to it.
+    var box = menu[0].getBoundingClientRect();
+    var overflowX = box.right - document.documentElement.clientWidth;
+    var overflowY = box.bottom - document.documentElement.clientHeight;
+    if (overflowX > 0) menu.css('left', Math.max(0, parseFloat(menu.css('left')) - overflowX - 4));
+    if (overflowY > 0) menu.css('top', Math.max(0, parseFloat(menu.css('top')) - overflowY - 4));
+
+    // dismissed by clicking away or by Escape, like any other menu
+    var dismiss = function (event) {
+      if (event.type === 'keydown' && event.key !== 'Escape') return;
+      self.closeMenu();
+      $(document).off('mousedown', dismiss).off('keydown', dismiss);
+    };
+    // next tick: the click that opened this must not also close it
+    setTimeout(function () {
+      $(document).on('mousedown', dismiss).on('keydown', dismiss);
+    }, 0);
+  };
+
+  /* -------------------- documentation editor ------------------- */
+
+  /**
+   * WebGME opens its rich-text editor here. A plain textarea is the
+   * honest equivalent: the attribute is text either way, and the
+   * widget only cares that it gets the new value back.
+   */
+  PlaygroundHost.prototype.editDocument = function (text, onSave) {
+    var overlay = $('<div class="pg-overlay"></div>');
+    var box = $('<div class="pg-dialog" role="dialog" aria-modal="true" ' +
+                'aria-label="Edit documentation"></div>');
+    var area = $('<textarea class="pg-doc" spellcheck="false"></textarea>')
+        .val(text || '');
+    var buttons = $('<div class="pg-dialog-buttons"></div>');
+    var cancel = $('<button type="button">Cancel</button>');
+    var save = $('<button type="button" class="primary">Save</button>');
+
+    function close() {
+      overlay.remove();
+      $(document).off('keydown', onKey);
+    }
+    function onKey(event) {
+      if (event.key === 'Escape') close();
+    }
+
+    cancel.on('click', close);
+    save.on('click', function () {
+      var value = area.val();
+      close();
+      if (onSave) onSave(value);
+    });
+    // clicking the backdrop cancels; clicking the dialog must not
+    overlay.on('click', function (event) {
+      if (event.target === overlay[0]) close();
+    });
+
+    box.append($('<h3>Documentation</h3>'), area,
+               buttons.append(cancel, save));
+    overlay.append(box);
+    $(document.body).append(overlay);
+    $(document).on('keydown', onKey);
+    area.focus();
+  };
+
+  /* ------------------------ drag and drop ---------------------- */
+
+  PlaygroundHost.prototype.makeDroppable = function (element, handlers) {
+    var self = this;
+    var el = elementOf(element);
+    if (!el) return undefined;
+    var target = { el: el, handlers: handlers || {}, inside: false };
+    self._targets.push(target);
+    return function () {
+      self._targets = self._targets.filter(function (t) { return t !== target; });
+    };
+  };
+
+  function isInside(el, event) {
+    var box = el.getBoundingClientRect();
+    return event.clientX >= box.left && event.clientX <= box.right &&
+           event.clientY >= box.top && event.clientY <= box.bottom;
+  }
+
+  /**
+   * Start dragging palette items. Not part of the HostServices
+   * contract -- where a drag COMES FROM is the host's business, and
+   * the widget only ever receives the drop.
+   *
+   * @param payload  { items: ['<type name>'], effects: [] } -- the
+   *                 normalized descriptor the contract promises
+   * @param event    the mousedown that started it
+   * @param label    what to show under the pointer
+   */
+  PlaygroundHost.prototype.startDrag = function (payload, event, label) {
+    var self = this;
+    if (self._drag) self._endDrag();
+
+    // `pointer-events: none` matters: with the ghost under the
+    // pointer, cytoscape's container would stop receiving mousemove
+    // and the widget would never learn which node it is over.
+    var ghost = $('<div class="pg-drag-ghost"></div>').text(label || '');
+    $(document.body).append(ghost);
+
+    var drag = self._drag = { payload: payload, ghost: ghost };
+
+    drag.move = function (moveEvent) {
+      ghost.css({ left: moveEvent.pageX + 12, top: moveEvent.pageY + 12 });
+      self._targets.forEach(function (target) {
+        var inside = isInside(target.el, moveEvent);
+        if (inside === target.inside) return;
+        target.inside = inside;
+        var handler = inside ? target.handlers.over : target.handlers.out;
+        if (handler) handler(moveEvent, payload);
+      });
+    };
+
+    drag.up = function (upEvent) {
+      var dropped = self._targets.filter(function (target) {
+        return isInside(target.el, upEvent);
+      });
+      self._endDrag(upEvent);
+      dropped.forEach(function (target) {
+        if (target.handlers.drop) target.handlers.drop(upEvent, payload);
+      });
+    };
+
+    drag.key = function (keyEvent) {
+      if (keyEvent.key === 'Escape') self._endDrag(keyEvent);
+    };
+
+    $(document).on('mousemove', drag.move)
+               .on('mouseup', drag.up)
+               .on('keydown', drag.key);
+    drag.move(event);
+  };
+
+  PlaygroundHost.prototype._endDrag = function (event) {
+    var drag = this._drag;
+    if (!drag) return;
+    this._drag = null;
+    drag.ghost.remove();
+    $(document).off('mousemove', drag.move)
+               .off('mouseup', drag.up)
+               .off('keydown', drag.key);
+    // every target that thought it was under the pointer is not any
+    // more, so the widget can clear its drop highlighting
+    this._targets.forEach(function (target) {
+      if (!target.inside) return;
+      target.inside = false;
+      if (target.handlers.out) target.handlers.out(event, drag.payload);
+    });
+  };
+
+  /** tear down anything still on screen */
+  PlaygroundHost.prototype.destroy = function () {
+    this._endDrag();
+    this.closeMenu();
+    this._targets = [];
+  };
+
+  return function () {
+    return HostServices.assertImplements(new PlaygroundHost(), 'PlaygroundHost');
+  };
+});

--- a/web/palette.js
+++ b/web/palette.js
@@ -13,20 +13,13 @@
  * `backend.getNodeInfo`, which answers for type names as well as for
  * objects. Nothing here needs to know how a node gets created.
  */
-define(['jquery', 'hfsm/metaRules'], function ($, metaRules) {
+define(['jquery', 'hfsm/viz/describe'], function ($, describe) {
   'use strict';
 
-  /**
-   * Everything the metamodel can instantiate, minus the connections:
-   * a transition is DRAWN between two states with the edge handle,
-   * not dropped onto one, and offering it here would only produce
-   * drops the widget has to refuse.
-   */
-  function creatableTypes() {
-    return metaRules.concreteTypes().filter(function (name) {
-      return !metaRules.isConnection(name);
-    });
-  }
+  // What may be offered is a display rule, not a palette rule: it is
+  // the same question as "does the diagram draw this", which both
+  // hosts have to agree on. `describe` owns it.
+  var creatableTypes = describe.creatableTypes;
 
   /**
    * @param container  where to build it

--- a/web/palette.js
+++ b/web/palette.js
@@ -1,0 +1,62 @@
+/**
+ * The playground's part palette.
+ *
+ * WebGME has a part browser fed by the project's meta aspect. Here
+ * the metamodel is `src/common/meta.json`, generated from the same
+ * WebGME project (scripts/gen-meta.js) and already the thing that
+ * decides what LocalBackend will let you create -- so the palette is
+ * derived from it rather than listed by hand. A type added to the
+ * metamodel shows up here without anyone remembering to add it.
+ *
+ * A palette entry is dragged onto the graph, and what identifies it
+ * is the TYPE NAME: the widget hands that straight to
+ * `backend.getNodeInfo`, which answers for type names as well as for
+ * objects. Nothing here needs to know how a node gets created.
+ */
+define(['jquery', 'hfsm/metaRules'], function ($, metaRules) {
+  'use strict';
+
+  /**
+   * Everything the metamodel can instantiate, minus the connections:
+   * a transition is DRAWN between two states with the edge handle,
+   * not dropped onto one, and offering it here would only produce
+   * drops the widget has to refuse.
+   */
+  function creatableTypes() {
+    return metaRules.concreteTypes().filter(function (name) {
+      return !metaRules.isConnection(name);
+    });
+  }
+
+  /**
+   * @param container  where to build it
+   * @param host       the PlaygroundHost, which owns the drag
+   * @return a function that takes the palette down
+   */
+  function build(container, host) {
+    var root = $('<div class="viz-palette" role="toolbar" ' +
+                 'aria-label="Model parts"></div>');
+    $('<span class="viz-palette-label">Drag to add:</span>').appendTo(root);
+
+    creatableTypes().forEach(function (type) {
+      $('<button type="button" class="viz-part"></button>')
+        .text(type)
+        .attr('title', 'Drag ' + type + ' onto a state to add one')
+        .on('mousedown', function (event) {
+          // left button only, and never the browser's own drag
+          if (event.which !== 1) return;
+          event.preventDefault();
+          host.startDrag({ items: [type], effects: [] }, event, type);
+        })
+        .appendTo(root);
+    });
+
+    $(container).append(root);
+    return function () { root.remove(); };
+  }
+
+  return {
+    creatableTypes: creatableTypes,
+    build: build,
+  };
+});

--- a/web/viz.js
+++ b/web/viz.js
@@ -258,16 +258,27 @@ define([
     // automatically, and that arrangement is just as much "how the
     // diagram looks" as a drag is -- saving only the drags would
     // leave the next load to arrange it all over again, differently.
+    //
+    // Serialized from a COPY, and through the widget's own
+    // conversion. This used to write `node.position()` -- cytoscape's
+    // CENTRE -- straight into the mounted model, which means the
+    // TOP-LEFT and is the model the widget is running on. So every
+    // save moved every node by half its own size, and the page saves
+    // after each edit: the model then disagreed with the graph by
+    // that much, and the NEXT drag saw the difference and
+    // "corrected" it. The first drag looked right and the second
+    // shifted the whole diagram.
+    var out = JSON.parse(JSON.stringify(model));
     widget._cy.nodes().forEach(function (node) {
-      var object = model.objects[node.id()];
+      var object = out.objects[node.id()];
       if (!object) return;
-      var p = node.position();
+      var p = widget.cyPosition(node);   // top-left, as the model means it
       if (typeof p.x === 'number' && typeof p.y === 'number') {
         object.position = { x: p.x, y: p.y };
       }
     });
 
-    return exportModel.toJSON(model, {});
+    return exportModel.toJSON(out, {});
   }
 
   return {

--- a/web/viz.js
+++ b/web/viz.js
@@ -4,13 +4,15 @@
  *
  * There is no WebGME here: no client, no territories, no server. The
  * widget takes its model through a ModelBackend and its UI services
- * through HostServices, so all this has to supply is a LocalBackend
- * over the parsed JSON and a host that offers nothing (the playground
- * is read-only for now -- editing is the next step).
+ * through HostServices, so all this supplies is a LocalBackend over
+ * the parsed JSON and a host built out of plain DOM.
  *
  * The node feed mirrors what the WebGME control does: build a
  * descriptor per object and hand each to the widget, which sorts out
- * the ordering itself through its own dependency tracking.
+ * the ordering itself through its own dependency tracking. Where the
+ * control is told exactly what changed by a territory, here the
+ * difference is worked out after each committed transaction -- see
+ * `sync`.
  */
 define([
   'jquery',
@@ -22,16 +24,17 @@ define([
   'cytoscape-panzoom',
   'hfsm/resolveModel',
   'hfsm/viz/LocalBackend',
-  'hfsm/viz/HostServices',
   'hfsm/viz/describe',
   'hfsm/exportModel',
   'widgets/HFSMViz/HFSMVizWidget',
+  './host',
+  './palette',
   // the dialogs are bootstrap modals; nothing imports it, so it is
   // listed here to guarantee it is on the page before one opens
   'bootstrap',
 ], function ($, _, cytoscape, coseBilkent, edgehandles, contextMenus, panzoom,
-             resolveModel, LocalBackend, HostServices, describe, exportModel,
-             HFSMVizWidget) {
+             resolveModel, LocalBackend, describe, exportModel,
+             HFSMVizWidget, PlaygroundHost, palette) {
   'use strict';
 
   // Cytoscape's extensions are UMD bundles that EXPORT a register
@@ -67,11 +70,26 @@ define([
   var widget = null;
   var backend = null;
   var model = null;
+  var host = null;
+  var removePalette = null;
+  // what the widget was last told about each object, so a change can
+  // be turned into the add / update / remove calls it expects
+  var shown = {};
+  var onModelEdited = null;
 
   function destroy() {
+    if (removePalette) {
+      try { removePalette(); } catch (e) { console.error(e); }
+      removePalette = null;
+    }
+    if (host) {
+      try { host.destroy(); } catch (e) { console.error(e); }
+      host = null;
+    }
     if (widget) {
       try { widget.destroy(); } catch (e) { console.error(e); }
     }
+    shown = {};
     // cleared whatever happened above, and whether or not a widget
     // was ever built: `mount` sets the backend before the widget, so
     // a constructor that throws part-way would otherwise leave this
@@ -79,6 +97,56 @@ define([
     widget = null;
     backend = null;
     model = null;
+  }
+
+  /**
+   * Bring the graph in line with the model.
+   *
+   * WebGME's control is told exactly which nodes loaded, changed or
+   * went away, by the territory it opened. A LocalBackend transaction
+   * only reports THAT something committed, so the difference is
+   * worked out here by comparing each object's descriptor against
+   * what the widget was last given. At the size of a state machine
+   * that costs nothing, and it means both hosts drive the widget
+   * through the same three calls rather than editing needing a
+   * second update path of its own.
+   *
+   * @return how many drawable objects have no position, which is what
+   *         decides whether a freshly loaded model gets laid out
+   */
+  function sync(opts) {
+    if (!widget || !backend) return 0;
+    var quiet = !!(opts && opts.quiet);
+    var unpositioned = 0;
+    var present = {};
+
+    Object.keys(model.objects).sort().forEach(function (path) {
+      var desc = describe.finish(backend.getNode(path));
+      if (!desc) return;
+      present[path] = true;
+      // an edge is drawn from its endpoints, so only the boxes need a
+      // position of their own
+      if (!desc.isConnection && !model.objects[path].position) {
+        unpositioned++;
+      }
+      var current = JSON.stringify(desc);
+      if (!(path in shown)) {
+        shown[path] = current;
+        widget.addNode(desc);
+      } else if (shown[path] !== current) {
+        shown[path] = current;
+        widget.updateNode(desc);
+      }
+    });
+
+    Object.keys(shown).forEach(function (path) {
+      if (present[path]) return;
+      delete shown[path];
+      widget.removeNode(path);
+    });
+
+    if (!quiet && onModelEdited) onModelEdited();
+    return unpositioned;
   }
 
   /**
@@ -97,11 +165,23 @@ define([
     model = JSON.parse(JSON.stringify(rawModel));
     resolveModel.resolve(model);
 
-    backend = LocalBackend(model);
+    host = PlaygroundHost();
+    // the backend reports every committed transaction; that is the
+    // only notice the graph gets that the model has been edited
+    backend = LocalBackend(model, sync);
+
+    // The palette sits above the diagram, and the widget gets a
+    // container of its own: it draws into an absolutely positioned
+    // element filling whatever it is given, so it cannot share a box
+    // with anything else.
+    var root = $(container).empty();
+    removePalette = palette.build(root, host);
+    var widgetHost = $('<div class="viz-host"></div>').appendTo(root);
+
     widget = new HFSMVizWidget(
-      makeLogger('HFSMViz'), $(container), null,
+      makeLogger('HFSMViz'), widgetHost, null,
       function () { return backend; },
-      HostServices.none()
+      host
     );
 
     // A state machine reads as a flow from its initial state, so
@@ -128,17 +208,7 @@ define([
 
     // Feed the graph. Order does not matter: the widget defers any
     // node whose parent or endpoints have not arrived yet.
-    var unpositioned = 0;
-    Object.keys(model.objects).sort().forEach(function (path) {
-      var desc = describe.finish(backend.getNode(path));
-      if (!desc) return;
-      widget.addNode(desc);
-      // an edge is drawn from its endpoints, so only the boxes need a
-      // position of their own
-      if (!desc.isConnection && !model.objects[path].position) {
-        unpositioned++;
-      }
-    });
+    var unpositioned = sync({ quiet: true });
 
     // A model authored by hand -- or exported by the CLI -- carries no
     // layout, so every node would sit at (0, 0) in a heap. WebGME
@@ -203,6 +273,12 @@ define([
   return {
     mount: mount,
     destroy: destroy,
+    /**
+     * Called after every committed edit, so the page can write the
+     * model back into the editor. The diagram is an editor now, and
+     * the text beside it has to say the same thing.
+     */
+    onModelEdited: function (fn) { onModelEdited = fn; },
     resize: resize,
     currentModelJSON: currentModelJSON,
     /** the mounted widget, for the page to resize / refresh */


### PR DESCRIPTION
The visualizer already ran in the playground; it just could not change anything, because `HostServices.none()` stood in for the three things the widget needs from its host. This supplies them out of plain DOM, and adds the palette to drag from.

```js
new HFSMVizWidget(logger, container, null,
                  function () { return LocalBackend(model, sync); },
                  PlaygroundHost());
```

## What went in

**`web/host.js`** — a context menu, a documentation editor, and drag and drop. The drag is **mouse-based, not HTML5**: during an HTML5 drag the browser stops delivering `mousemove`/`mouseover`, and cytoscape learns which node the pointer is over from exactly those — so every drop would land with no parent and be refused. jQuery UI, which WebGME drags with, is mouse-based for the same reason.

**`web/palette.js`** — derived from `src/common/meta.json`, the same generated metamodel that decides what `LocalBackend` will let you create. A type added to the metamodel appears without anyone remembering to add it, and the connections are left out because a transition is *drawn*, not dropped.

**`LocalBackend.getNodeInfo`** now answers for type names as well as object ids. A palette entry names a TYPE; WebGME has a meta node with an id of its own to answer that, and a local store has only the metamodel, where the name is the whole identity. The widget asks the backend rather than resolving types itself, which is what lets a host bring its own palette.

**`viz.js`** turns each committed transaction into the `addNode`/`updateNode`/`removeNode` calls the widget expects, by diffing descriptors against what it was last told. WebGME gets that from a territory; a `LocalBackend` transaction only reports *that* something committed. Both hosts drive the widget through the same three calls.

**`app.js`** writes the model back into the editor after every committed change, so the text and the diagram cannot disagree — and `Save layout`, which refuses when they do, stays usable. Generation is not re-run: that is the slow half, and the user says when.

## Two defects in the shared widget, both invisible from WebGME

**`edgeContextMenu` threw.** It still used the old WebGME-only `_relativeToWindowPos`, which adds the offsets of `.panel-base-wh` and `.ui-layout-pane-center`. Those match nothing elsewhere, so `.position()` returned undefined and reading `.left` threw — inside an edgehandles callback, where it was swallowed. Releasing a transition onto a state simply did nothing outside WebGME. It now measures the container, which gives WebGME the identical answer: checked in the running editor, delta (0, 0).

**The drop highlight stuck.** "You can drop here" was left for the next hover event to clear, which never arrives if the pointer stops moving, so the state stayed lit after a drop.

## Verification

In the browser: dragging `State` into the machine creates one and the text follows; `Add child...` creates a named state with its attributes; the connection menu offers `External Transition` and choosing it wires `src` and `dst`; the documentation editor saves; deleting removes the node and its edges; generating from the edited model produces 12 files with no diagnostics. WebGME re-checked and unchanged.

Node tests cover the handover that can silently rot — a type the palette offers but the backend will not resolve produces a drag that lands and does nothing, with no error anywhere.

**Not covered by automation:** the edge-handle *gesture* itself. Synthetic events cannot drive edgehandles' hover state machine, and the harness's drag is faster than its 150 ms delay. The `complete` callback it ends in is exercised directly.

## Next

An existing node's attributes still cannot be changed from the diagram — they are set at creation, and Documentation has its own editor. In WebGME that is the Property Editor, part of the *application* rather than of the visualizer, so it did not come across with the widget. That is the obvious next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy