### PR TITLE
An inspector for the selected node's attributes

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -17,6 +17,11 @@ config.requirejsPaths['bower'] = "./bower_components/";
 config.requirejsPaths['cytoscape-edgehandles'] = "./bower_components/cytoscape-edgehandles/cytoscape-edgehandles";
 config.requirejsPaths['cytoscape-context-menus'] = "./bower_components/cytoscape-context-menus/cytoscape-context-menus";
 config.requirejsPaths['cytoscape-panzoom'] = "./bower_components/cytoscape-panzoom/cytoscape-panzoom";
+// The visualizer edits code attributes in CodeMirror. Taken from npm
+// rather than bower so both hosts run the SAME version: the
+// playground vendors this very directory (scripts/build-web.sh) and
+// maps the same id onto it.
+config.requirejsPaths['codemirror'] = "./node_modules/codemirror";
 
 // Merging config
 config.storage.autoMerge.enable = true;

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -66,7 +66,10 @@ place. It is deliberately not a property grid:
 - C++ attributes are edited in CodeMirror, with highlighting, and the
   ⤡ button opens the same text full-size in a modal — with line
   numbers, and Ctrl/Cmd+Enter to save — because a 250px column is not
-  where anyone wants to write a state's Entry block;
+  where anyone wants to write a state's Entry block. Documentation
+  gets the same button: it is prose rather than C++, so it is wrapped
+  and unhighlighted instead of numbered, but the need for room is the
+  same;
 - a `name` or an `Event` that is not a C++ identifier is refused as it
   is typed, with the reason, instead of failing later in the generator
   — or, for an event name, reaching the simulator, which reports it

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -42,16 +42,39 @@ the templates, or the page itself.
 - **Draw** it: the **Diagram** tab renders the machine as a UML state
   chart and runs the simulator against it — fire events, watch the
   active state move, step through guards and choice pseudostates.
-- **Edit** it: drag a part from the palette into a state, or use
-  **Add child...** from a state's context menu to fill in its
-  attributes as you create it; draw a transition between two states
-  with the handle on the source; move things around; edit a
-  Documentation block; delete a node and the transitions that hung
-  off it. Every committed change is written back into the model text
-  beside the diagram, so the two never disagree; press **Generate**
-  when you want the code to catch up.
+- **Edit** it: drag a part from the palette into a state, draw a
+  transition between two states with the handle on the source, move
+  things around, delete a node and the transitions that hung off it.
+  Selecting anything shows its attributes in the panel beside the
+  diagram, where they can be changed: a state's name, its Entry / Exit
+  / Tick, its timer period; a transition's Event, Guard and Action.
+  Every committed change is written back into the model text beside
+  the diagram, so the two never disagree; press **Generate** when you
+  want the code to catch up.
 - **Take it away**: view any file, copy it, download one, or download
   all of them.
+
+### Editing attributes
+
+The panel under the diagram shows whatever is selected — a state, a
+transition, a pseudostate — and lets its attributes be edited in
+place. It is deliberately not a property grid:
+
+- fields are ordered by what the machine **does** (name, Event, Guard,
+  Action, Entry/Exit/Tick) with the rarely-touched declarations last,
+  rather than alphabetically;
+- C++ attributes are rendered as code in a growing textarea, not in a
+  one-line input;
+- a `name` or an `Event` that is not a C++ identifier is refused as it
+  is typed, with the reason, instead of failing later in the generator
+  — or, for an event name, reaching the simulator, which reports it
+  with a modal;
+- each committed field is one transaction, so it is one undo in a host
+  that has undo.
+
+What may be edited comes from the metamodel through
+`ModelBackend.getNodeSchema`, so the form cannot drift from what the
+model actually allows.
 
 ### The same visualizer, not a second one
 
@@ -93,13 +116,12 @@ generation still works.
 - **No undo.** WebGME's undo is a property of its commit history,
   which is exactly the infrastructure this does without. Reload to
   get back to the model you loaded.
-- **No editing an existing node's attributes** from the diagram. They
-  are set when the node is created (**Add child...**), and Documentation
-  has its own editor; after that, change them in the model text. In
-  WebGME this is the Property Editor's job, which is part of its
-  application rather than of the visualizer — so it is the next thing
-  the playground needs, not something that came across with the
-  widget.
+- **No pop-out code editor yet.** Code attributes are edited in the
+  panel, in a textarea that grows with its contents. Anything longer
+  than a few lines wants a real editor with highlighting, and wants to
+  be shown in the context the generator will place it in — which the
+  `//::::<path>::::<attribute>::::` markers in the generated files
+  make locatable. That is the next thing.
 
 ## Why it cannot drift from the CLI
 

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -63,8 +63,10 @@ place. It is deliberately not a property grid:
 - fields are ordered by what the machine **does** (name, Event, Guard,
   Action, Entry/Exit/Tick) with the rarely-touched declarations last,
   rather than alphabetically;
-- C++ attributes are rendered as code in a growing textarea, not in a
-  one-line input;
+- C++ attributes are edited in CodeMirror, with highlighting, and the
+  ⤡ button opens the same text full-size in a modal — with line
+  numbers, and Ctrl/Cmd+Enter to save — because a 250px column is not
+  where anyone wants to write a state's Entry block;
 - a `name` or an `Event` that is not a C++ identifier is refused as it
   is typed, with the reason, instead of failing later in the generator
   — or, for an event name, reaching the simulator, which reports it
@@ -75,6 +77,11 @@ place. It is deliberately not a property grid:
 What may be edited comes from the metamodel through
 `ModelBackend.getNodeSchema`, so the form cannot drift from what the
 model actually allows.
+
+CodeMirror is fetched the first time a code field is shown, not when
+the visualizer loads: it is the editor WebGME already bundles and
+webgme-codeeditor is built on, so both hosts map the id `codemirror`
+onto the same copy and neither pays for it until it is used.
 
 ### The same visualizer, not a second one
 
@@ -116,12 +123,10 @@ generation still works.
 - **No undo.** WebGME's undo is a property of its commit history,
   which is exactly the infrastructure this does without. Reload to
   get back to the model you loaded.
-- **No pop-out code editor yet.** Code attributes are edited in the
-  panel, in a textarea that grows with its contents. Anything longer
-  than a few lines wants a real editor with highlighting, and wants to
-  be shown in the context the generator will place it in — which the
-  `//::::<path>::::<attribute>::::` markers in the generated files
-  make locatable. That is the next thing.
+- **The code editor does not yet show its surroundings.** A snippet is
+  edited on its own, not inside the function the generator will put it
+  in. The `//::::<path>::::<attribute>::::` markers in the generated
+  files make that locatable, so it is the next thing.
 
 ## Why it cannot drift from the CLI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "codemirror": "^5.65.21",
         "handlebars": "^4.7.8",
         "requirejs": "^2.3.5",
         "requirejs-text": "^2.0.15",
@@ -24,7 +25,6 @@
       },
       "devDependencies": {
         "chai": "^3.0.0",
-        "codemirror": "^5.65.21",
         "mocha": "^12.0.0",
         "rimraf": "^2.7.1"
       }
@@ -1515,7 +1515,6 @@
       "version": "5.65.21",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
       "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "http://github.com/finger563/webgme-hfsm.git"
   },
   "dependencies": {
+    "codemirror": "^5.65.21",
     "handlebars": "^4.7.8",
     "requirejs": "^2.3.5",
     "requirejs-text": "^2.0.15",
@@ -31,7 +32,6 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "codemirror": "^5.65.21",
     "mocha": "^12.0.0",
     "rimraf": "^2.7.1"
   },

--- a/src/common/checkModel.js
+++ b/src/common/checkModel.js
@@ -76,6 +76,27 @@ define([], function() {
      * checker refuses. Two implementations of this would disagree,
      * and the one in the editor would be the one nobody tested.
      */
+    /**
+     * Why `value` is not usable as this attribute on a node of this
+     * type, or null. The editor's single entry point into these
+     * rules, so it can refuse exactly what the checker refuses.
+     */
+    identifierProblem: function(type, attribute, value) {
+      var self = this;
+      if (attribute === 'Event') {
+        // a transition's trigger is emitted verbatim, like an Event
+        // definition's name (checkEvent)
+        var raw = String(value == null ? '' : value);
+        if (!raw) return null;          // no trigger is a real thing to be
+        return self.isValidString(raw) ? null : 'Not a usable C++ name.';
+      }
+      if (attribute === 'name') {
+        if (!String(value == null ? '' : value)) return 'A name is required.';
+        return self.nameProblem(type, value);
+      }
+      return null;
+    },
+
     nameProblem: function(type, name) {
       var self = this;
       var raw = String(name == null ? '' : name);

--- a/src/common/checkModel.js
+++ b/src/common/checkModel.js
@@ -58,6 +58,44 @@ define([], function() {
       var varDeclExp = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
       return varDeclExp.test(str) && this.reservedNames.indexOf(str) === -1;
     },
+    /**
+     * Why `name` is not usable on a node of this type, or null.
+     *
+     * The rule differs by type, and every difference is deliberate:
+     *
+     *  - most names are SANITIZED first, so "State 1" is fine and is
+     *    emitted as State_1;
+     *  - an Event or a Field name is emitted and matched VERBATIM, so
+     *    'BUTTON-PRESS' has to be rejected rather than quietly
+     *    becoming BUTTON_PRESS;
+     *  - 'End_State' is reserved so that nothing else collides with
+     *    the generated class, which means the End State itself is the
+     *    one object allowed to be called it.
+     *
+     * Exported because the editor has to refuse exactly what the
+     * checker refuses. Two implementations of this would disagree,
+     * and the one in the editor would be the one nobody tested.
+     */
+    nameProblem: function(type, name) {
+      var self = this;
+      var raw = String(name == null ? '' : name);
+      if (type === 'Event' || type === 'Field') {
+        return self.isValidString(raw) ? null :
+          type + ' names must be valid C++ identifiers (alphanumeric ' +
+          '+ underscore, starting with a letter).';
+      }
+      var sanitized = self.sanitizeString(raw);
+      if (type === 'End State' && sanitized === 'End_State') {
+        return null;   // the conventional default name
+      }
+      if (!self.isValidString(sanitized)) {
+        return type === 'End State'
+          ? 'End State names must be valid C++ identifiers.'
+          : 'Not a usable C++ name.';
+      }
+      return null;
+    },
+
     checkName: function(obj) {
       var self = this;
       var sName = self.sanitizeString(obj.name);

--- a/src/common/viz/LocalBackend.js
+++ b/src/common/viz/LocalBackend.js
@@ -172,26 +172,40 @@ define(['./ModelBackend', '../metaRules'], function (ModelBackend, metaRules) {
     });
   };
 
+  /** the schema of one type, whatever the caller wants it for */
+  function schemaOf(name) {
+    var type = TYPES[name];
+    if (!type) return null;
+    return {
+      name: name,
+      typeId: name,
+      isConnection: !!type.isConnection,
+      attributes: Object.keys(type.attributes).sort().map(function (attr) {
+        return {
+          name: attr,
+          type: type.attributes[attr].type,
+          defaultValue: type.attributes[attr].default,
+        };
+      }),
+    };
+  }
+
+  /**
+   * What THIS node's type declares -- deliberately not filtered by
+   * cardinality, which is a question about creating another one and
+   * has nothing to do with editing the one that exists.
+   */
+  LocalBackend.prototype.getNodeSchema = function (id) {
+    var obj = this._objects()[id];
+    return obj ? schemaOf(obj.type) : null;
+  };
+
   // same cardinality filtering as getValidChildTypes: a form must
   // not offer to create what cannot be created
   LocalBackend.prototype.getChildTypeSchemas = function (parentId) {
     var parent = this._objects()[parentId];
     if (!parent) return [];
-    return Object.keys(this.getValidChildTypes(parentId)).sort().map(function (name) {
-      var type = TYPES[name];
-      return {
-        name: name,
-        typeId: name,
-        isConnection: !!type.isConnection,
-        attributes: Object.keys(type.attributes).sort().map(function (attr) {
-          return {
-            name: attr,
-            type: type.attributes[attr].type,
-            defaultValue: type.attributes[attr].default,
-          };
-        }),
-      };
-    });
+    return Object.keys(this.getValidChildTypes(parentId)).sort().map(schemaOf);
   };
 
   LocalBackend.prototype.getAttribute = function (id, name) {

--- a/src/common/viz/ModelBackend.js
+++ b/src/common/viz/ModelBackend.js
@@ -61,6 +61,22 @@
  * with -- a form must SHOW it, or every field the user leaves alone
  * gets written back as empty over the default.
  *
+ * getNodeSchema(id)
+ * -----------------
+ * The same shape, for the type a node ALREADY has:
+ *
+ *   { name, typeId, isConnection,
+ *     attributes: [{ name, type, defaultValue }] }
+ *
+ * `getChildTypeSchemas` cannot answer this. It is scoped to a parent
+ * and filtered by cardinality, so the schema of the one Initial a
+ * state is allowed has already been excluded from its parent's list
+ * by the time that Initial exists. Editing an existing node needs to
+ * know what attributes it has -- and their declared types -- without
+ * asking whether another one could be created.
+ *
+ * Returns null for an id the store does not know.
+ *
  * getAttribute(id, name) reads one attribute off a node -- the escape
  * hatch for the few callers that need a value the descriptors do not
  * carry (e.g. comparing a form field against what a node already has
@@ -98,8 +114,8 @@ define([], function () {
   var REQUIRED = [
     // reads
     'getNode', 'getChildren', 'getNodeInfo', 'getValidChildTypes',
-    'getValidConnectionTypes', 'getChildTypeSchemas', 'getAttribute',
-    'isReadOnly',
+    'getValidConnectionTypes', 'getChildTypeSchemas', 'getNodeSchema',
+    'getAttribute', 'isReadOnly',
     // mutations
     'transact', 'createChild', 'createInstances', 'setAttribute',
     'setPointer', 'setPosition', 'deleteNodes', 'moveNodes', 'copyNodes',

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -130,7 +130,13 @@ define(['../metaRules'], function (metaRules) {
       };
       return (attributes || []).slice().sort(function (a, b) {
         var d = rank(a) - rank(b);
-        return d !== 0 ? d : (a.name < b.name ? -1 : 1);
+        if (d !== 0) return d;
+        // 0 for equal names, as Array.sort's contract requires -- two
+        // attributes of a type cannot share a name, but a comparator
+        // that never says "equal" is the kind of thing that sorts
+        // differently in a different engine
+        if (a.name === b.name) return 0;
+        return a.name < b.name ? -1 : 1;
       });
     },
 

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -48,8 +48,23 @@ define(['../metaRules'], function (metaRules) {
    */
   var IDENTIFIER_ATTRIBUTES = ['name', 'Event'];
 
+  /**
+   * Whether the diagram labels this by its EVENT rather than by its
+   * name -- which is what a transition is, connection or not: an
+   * Internal Transition is a child rather than an edge, and still
+   * reads `EVENT [guard]`.
+   *
+   * @param what  a descriptor ({type, isConnection}) or a schema
+   *              ({name, isConnection})
+   */
+  function labelledByEvent(what) {
+    if (!what) return false;
+    return !!what.isConnection ||
+      what.type === 'Internal Transition' || what.name === 'Internal Transition';
+  }
+
   function isTransition(desc) {
-    return desc.isConnection || desc.type === 'Internal Transition';
+    return labelledByEvent(desc);
   }
 
   return {
@@ -73,6 +88,29 @@ define(['../metaRules'], function (metaRules) {
       if (attr.type === 'float' || attr.type === 'integer') return 'number';
       if (CODE_ATTRIBUTES.indexOf(attr.name) > -1) return 'code';
       return 'text';
+    },
+
+    labelledByEvent: labelledByEvent,
+
+    /**
+     * The attributes worth putting in front of someone editing a node
+     * of this type, in the order to show them.
+     *
+     * A transition's `name` is left out. It is bookkeeping: the
+     * generator never emits it -- rename every transition in a model
+     * and the generated code is byte for byte the same -- and the
+     * diagram labels a transition `EVENT [guard]`, so nothing shows
+     * it either. A field that looks like it matters and changes
+     * nothing is worse than no field.
+     *
+     * @param schema  from getNodeSchema / getChildTypeSchemas
+     */
+    editableAttributes: function (schema) {
+      var attributes = (schema && schema.attributes) || [];
+      if (labelledByEvent(schema)) {
+        attributes = attributes.filter(function (a) { return a.name !== 'name'; });
+      }
+      return this.fieldOrder(attributes);
     },
 
     /**

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -25,6 +25,29 @@ define(['../metaRules'], function (metaRules) {
   // library at the top of it
   var CONTAINER_TYPES = ['State', 'State Machine', 'Library'];
 
+  /**
+   * Attributes that hold C++ rather than a value.
+   *
+   * The metamodel calls all of them 'string', because to the model
+   * they are; but a one-line input for an Entry block is the reason
+   * editing a machine through a property grid is miserable. This is
+   * exactly the set the generator emits as a code block, each behind
+   * a `//::::<path>::::<attribute>::::` marker -- so it is also the
+   * set whose text can be located in the generated file.
+   */
+  var CODE_ATTRIBUTES = [
+    'Action', 'Declarations', 'Definitions', 'Entry', 'Exit', 'Guard',
+    'Includes', 'Initialization', 'Tick',
+  ];
+
+  /**
+   * Attributes that must be a C++ identifier, so the generator can
+   * name something after them. Checked as they are typed, rather than
+   * left to fail at generation -- or, for an event name, to reach the
+   * simulator, which says so with a modal.
+   */
+  var IDENTIFIER_ATTRIBUTES = ['name', 'Event'];
+
   function isTransition(desc) {
     return desc.isConnection || desc.type === 'Internal Transition';
   }
@@ -32,6 +55,46 @@ define(['../metaRules'], function (metaRules) {
   return {
     ROOT_TYPES: ROOT_TYPES,
     NON_GRAPH_TYPES: NON_GRAPH_TYPES,
+    CODE_ATTRIBUTES: CODE_ATTRIBUTES,
+    IDENTIFIER_ATTRIBUTES: IDENTIFIER_ATTRIBUTES,
+
+    /**
+     * Which input an attribute wants, from its declared type and its
+     * name. One answer for every form -- the create dialog and the
+     * inspector have to agree, or the same attribute is a textarea in
+     * one and a one-line input in the other.
+     *
+     * @param attr  { name, type } from a schema
+     * @return 'checkbox' | 'number' | 'code' | 'text'
+     */
+    fieldKind: function (attr) {
+      if (!attr) return 'text';
+      if (attr.type === 'boolean') return 'checkbox';
+      if (attr.type === 'float' || attr.type === 'integer') return 'number';
+      if (CODE_ATTRIBUTES.indexOf(attr.name) > -1) return 'code';
+      return 'text';
+    },
+
+    /**
+     * The order to show attributes in: what the machine DOES first,
+     * then its name, then the rest. A property grid sorted
+     * alphabetically buries Entry under Declarations and Definitions.
+     */
+    fieldOrder: function (attributes) {
+      var rank = function (a) {
+        if (a.name === 'name') return 0;
+        if (a.name === 'Event') return 1;
+        if (a.name === 'Guard') return 2;
+        if (a.name === 'Action') return 3;
+        if (['Entry', 'Exit', 'Tick'].indexOf(a.name) > -1) return 4;
+        if (CODE_ATTRIBUTES.indexOf(a.name) > -1) return 6;
+        return 5;
+      };
+      return (attributes || []).slice().sort(function (a, b) {
+        var d = rank(a) - rank(b);
+        return d !== 0 ? d : (a.name < b.name ? -1 : 1);
+      });
+    },
 
     /**
      * The types a palette may offer for dropping onto the diagram.

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -41,6 +41,16 @@ define(['../metaRules'], function (metaRules) {
   ];
 
   /**
+   * Attributes that hold long-form TEXT rather than a value or code.
+   *
+   * `documentation` is markdown a person writes paragraphs in. It is
+   * not C++, so highlighting it as C++ would be a lie, and it is not
+   * a value, so a one-line input for it is the property-grid problem
+   * this panel exists to avoid.
+   */
+  var PROSE_ATTRIBUTES = ['documentation'];
+
+  /**
    * Attributes that must be a C++ identifier, so the generator can
    * name something after them. Checked as they are typed, rather than
    * left to fail at generation -- or, for an event name, to reach the
@@ -71,6 +81,7 @@ define(['../metaRules'], function (metaRules) {
     ROOT_TYPES: ROOT_TYPES,
     NON_GRAPH_TYPES: NON_GRAPH_TYPES,
     CODE_ATTRIBUTES: CODE_ATTRIBUTES,
+    PROSE_ATTRIBUTES: PROSE_ATTRIBUTES,
     IDENTIFIER_ATTRIBUTES: IDENTIFIER_ATTRIBUTES,
 
     /**
@@ -80,13 +91,14 @@ define(['../metaRules'], function (metaRules) {
      * one and a one-line input in the other.
      *
      * @param attr  { name, type } from a schema
-     * @return 'checkbox' | 'number' | 'code' | 'text'
+     * @return 'checkbox' | 'number' | 'code' | 'prose' | 'text'
      */
     fieldKind: function (attr) {
       if (!attr) return 'text';
       if (attr.type === 'boolean') return 'checkbox';
       if (attr.type === 'float' || attr.type === 'integer') return 'number';
       if (CODE_ATTRIBUTES.indexOf(attr.name) > -1) return 'code';
+      if (PROSE_ATTRIBUTES.indexOf(attr.name) > -1) return 'prose';
       return 'text';
     },
 

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -1146,10 +1146,17 @@ define([
 
     HFSMVizWidget.prototype.highlightNodes = function(nodes) {
       var self = this;
+      // ONE node is a selection like any other. WebGME's own selection
+      // always arrives here, plural, even when it is a single node --
+      // so treating this path as "many" left a node picked in the tree
+      // browser with no inspector at all.
+      var only = nodes && nodes.length === 1 ? nodes[0] : null;
+      if (only)
+        return self.highlightNode( only );
+
+      // More than one has no single set of values to show, and editing
+      // a field would have to mean writing it to all of them.
       self._simulator.hideStateInfo();
-      // one at a time: editing a field would otherwise have to mean
-      // writing it to every selected node, which is not what the
-      // single visible value would be saying
       self._simulator.showInspector( null );
     };
 
@@ -1157,6 +1164,10 @@ define([
       var self = this;
       self._cy.$(":selected").unselect();
       self._simulator.hideStateInfo();
+      // nothing is selected any more, so nothing should still be
+      // sitting there editable -- this is also the deselect path,
+      // through unselectNodes()
+      self._simulator.showInspector( null );
     };
 
     /* * * * * * * * Transition Selection  * * * * * * * */

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -230,6 +230,9 @@ define([
       if (self._cy) {
         self._cy.autoungrabify(self._readOnly);
       }
+      // the panel is showing editable fields for whatever is selected;
+      // whether they may be edited has just changed
+      self._simulator.update();
     };
 
     HFSMVizWidget.prototype._branchStatusChanged = function(args) {
@@ -242,6 +245,9 @@ define([
         self._unsavedNodePositions = {};
         self.branchChanged = true;
       }
+      // same reason as _branchChanged: read-only may have flipped
+      // under a selection that did not
+      self._simulator.update();
     };
 
     HFSMVizWidget.prototype._initialize = function () {
@@ -1137,10 +1143,19 @@ define([
     HFSMVizWidget.prototype.highlightNode = function(node) {
       var self = this;
       self._simulator.hideStateInfo();
-      // the inspector takes ANY node -- a transition has an Event and
+      // The inspector takes ANY node -- a transition has an Event and
       // a Guard to edit, and the UML preview below has nothing to say
-      // about one
-      self._simulator.showInspector( node.id() );
+      // about one.
+      //
+      // WHAT it shows comes from the SELECTION, not from this node.
+      // This runs once per cytoscape `select`, so ctrl-clicking a
+      // second element used to leave the first still sitting there
+      // editable while the diagram showed two selected -- one node's
+      // fields, captioned by a selection it was no longer alone in.
+      var selected = self._cy.$(':selected');
+      var only = selected.length ? (selected.length === 1 ? selected[0] : null)
+                                 : node;   // highlighted without selecting
+      self._simulator.showInspector( only ? only.id() : null );
       self._simulator.displayStateInfo( node.id() );
     };
 

--- a/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
+++ b/src/visualizers/widgets/HFSMViz/HFSMVizWidget.js
@@ -1137,12 +1137,20 @@ define([
     HFSMVizWidget.prototype.highlightNode = function(node) {
       var self = this;
       self._simulator.hideStateInfo();
+      // the inspector takes ANY node -- a transition has an Event and
+      // a Guard to edit, and the UML preview below has nothing to say
+      // about one
+      self._simulator.showInspector( node.id() );
       self._simulator.displayStateInfo( node.id() );
     };
 
     HFSMVizWidget.prototype.highlightNodes = function(nodes) {
       var self = this;
       self._simulator.hideStateInfo();
+      // one at a time: editing a field would otherwise have to mean
+      // writing it to every selected node, which is not what the
+      // single visible value would be saying
+      self._simulator.showInspector( null );
     };
 
     HFSMVizWidget.prototype.clear = function() {

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -157,11 +157,17 @@ define(['require'], function (require) {
         $('<span class="code-modal-subtitle"></span>').text(opts.subtitle || ''));
       var body = $('<div class="code-modal-body"></div>');
       var area = $('<textarea></textarea>').val(opts.value || '');
+      // read-only from the start: CodeMirror arrives asynchronously
+      // and may not arrive at all, and until it does this textarea is
+      // the editor -- editable, it would let a read-only model be
+      // changed and saved
+      if (opts.readOnly) area.prop('readonly', true);
       var buttons = $('<div class="code-modal-buttons"></div>');
       var hint = $('<span class="code-modal-hint"></span>')
           .text('Ctrl/Cmd+Enter saves, Esc cancels');
       var cancel = $('<button type="button">Cancel</button>');
       var save = $('<button type="button" class="primary">Save</button>');
+      if (opts.readOnly) save.prop('disabled', true);
 
       var opener = document.activeElement;
       var cm = null;
@@ -176,12 +182,26 @@ define(['require'], function (require) {
         close();
         if (opts.onSave) opts.onSave(value);
       }
+      /**
+       * Everything Tab can reach inside the dialog, in order.
+       *
+       * The EDITOR has to be in this list, not just the buttons.
+       * CodeMirror replaces the textarea with its own hidden input,
+       * so the set changes once it loads -- and a trap that only knew
+       * about buttons let Shift+Tab out of the first one and into the
+       * page behind the backdrop.
+       */
+      function focusables() {
+        return box.find('textarea, button, [tabindex]').filter(function () {
+          return !this.disabled && this.offsetParent !== null;
+        });
+      }
       function onKey(event) {
         if (event.key === 'Escape') { close(); return; }
         if (event.key !== 'Tab') return;
         // `aria-modal` has to be true of the behaviour, not just the
         // attribute: keep Tab inside
-        var items = box.find('button').filter(function () { return !this.disabled; });
+        var items = focusables();
         if (!items.length) return;
         var first = items.get(0), last = items.get(items.length - 1);
         var active = document.activeElement;

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -146,7 +146,11 @@ define(['require'], function (require) {
     /**
      * The same code, full size, in a modal.
      *
-     * @param opts  { title, subtitle, value, readOnly, onSave }
+     * @param opts  { title, subtitle, value, readOnly, prose, onSave }
+     *   `prose` for markdown rather than C++: wrapped, unnumbered and
+     *   unhighlighted, because paragraphs want the width and
+     *   colouring prose as code would be a lie. The room is the point
+     *   either way, which is why documentation gets this too.
      * @return a function that closes it
      */
     open: function (opts) {
@@ -158,7 +162,8 @@ define(['require'], function (require) {
       // screen reader reaches an unnamed one
       var titleId = 'code-modal-title-' + (++dialogCount);
       var box = $('<div class="code-modal" role="dialog" aria-modal="true"></div>')
-          .attr('aria-labelledby', titleId);
+          .attr('aria-labelledby', titleId)
+          .addClass(opts.prose ? 'is-prose' : 'is-code');
       var head = $('<div class="code-modal-head"></div>').append(
         $('<span class="code-modal-title"></span>')
           .attr('id', titleId).text(opts.title || 'Code'),
@@ -237,7 +242,9 @@ define(['require'], function (require) {
         CodeMirror = CM;
         if (!document.contains(area[0])) return;   // already closed
         cm = CodeMirror.fromTextArea(area[0], extend(COMMON, {
-          lineNumbers: true,
+          mode: opts.prose ? null : MODE,
+          lineNumbers: !opts.prose,
+          lineWrapping: !!opts.prose,
           readOnly: !!opts.readOnly,
           autofocus: true,
           extraKeys: {

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -1,0 +1,230 @@
+/**
+ * Editing a code attribute: highlighted where it sits, and bigger
+ * when it needs to be.
+ *
+ * A state's Entry block is C++, and the panel it lives in is a
+ * column about 250px wide. Two things follow. It should LOOK like
+ * code -- highlighted, monospaced, indented -- because that is most
+ * of what makes code readable at a glance. And anything longer than a
+ * few lines needs somewhere bigger to go, or the column dictates how
+ * much you are willing to write.
+ *
+ * So: CodeMirror in the row, and the same editor full-size in a modal
+ * one click away. The modal is the same text with more room, not a
+ * different editor.
+ *
+ * WHY CODEMIRROR
+ * --------------
+ * It is already in both hosts and needs no new dependency: WebGME
+ * bundles it for its own editors, webgme-codeeditor is built on it,
+ * and the playground already uses it for the model and the generated
+ * files. Both now map the id `codemirror` onto the SAME npm copy, so
+ * the widget can simply ask for it. Monaco would be a ~5MB vendored
+ * blob for a language service that, without a compiler, would give us
+ * about what `clike` already does.
+ */
+define(['require'], function (require) {
+  'use strict';
+
+  /**
+   * CodeMirror is fetched WHEN AN EDITOR IS FIRST OPENED, not when
+   * this module loads.
+   *
+   * Declaring it as a dependency puts it in the visualizer's load
+   * path, and doing that made the playground stop starting up: the
+   * module graph sat pending with no error, and the tab eventually
+   * stopped responding. It also made everyone pay for an editor most
+   * sessions never open. Loading it on demand does neither, and the
+   * first open costs one fetch of an already-vendored file.
+   */
+  var pending = null;
+  function editor() {
+    if (!pending) {
+      pending = new Promise(function (resolve, reject) {
+        require(['codemirror/lib/codemirror', 'codemirror/mode/clike/clike'],
+                function (CodeMirror) { resolve(CodeMirror); }, reject);
+      });
+    }
+    return pending;
+  }
+
+  /**
+   * CodeMirror's stylesheet, added as a plain <link>.
+   *
+   * NOT through `css!`, which is how every other stylesheet in this
+   * widget is loaded. Asking the require-css plugin for this one
+   * wedges the module loader: the whole graph sits pending, no error
+   * is raised, and the page never finishes starting up. Removing just
+   * that dependency is what made it load again. A link element needs
+   * no plugin and cannot block anything.
+   *
+   * Called when an editor is first opened rather than at load: this
+   * module is loaded in node by the tests that check the widget can
+   * live outside WebGME, and there is no `document` there.
+   */
+  function ensureStylesheet() {
+    var href = require.toUrl('codemirror/lib/codemirror.css');
+    var links = document.getElementsByTagName('link');
+    for (var i = 0; i < links.length; i++) {
+      if (links[i].href && links[i].href.indexOf('codemirror.css') > -1) return;
+    }
+    var link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = href;
+    document.head.appendChild(link);
+  }
+
+  // C++ -- the same mode the playground shows generated .hpp/.cpp in
+  var MODE = { name: 'text/x-c++src' };
+
+  var COMMON = {
+    mode: MODE,
+    lineWrapping: false,
+    indentUnit: 2,
+    tabSize: 2,
+    smartIndent: true,
+    matchBrackets: true,
+  };
+
+  function extend(base, more) {
+    var out = {};
+    Object.keys(base).forEach(function (k) { out[k] = base[k]; });
+    Object.keys(more || {}).forEach(function (k) { out[k] = more[k]; });
+    return out;
+  }
+
+  // tall enough for a few lines of an Entry block; longer code has
+  // the pop-out
+  var INLINE_HEIGHT = 64;
+
+  return {
+    /**
+     * Turn a textarea into a highlighted editor.
+     *
+     * Sized in PIXELS through the API rather than by CSS: the panel
+     * this sits in scrolls, so leaving the height to the content puts
+     * the editor and the panel's scrollbar in a measuring loop.
+     *
+     * Attaches when CodeMirror arrives, so the field is a working
+     * textarea in the meantime.
+     *
+     * @param textarea  the element to replace
+     * @param handlers  { onCommit, onExpand, onReady }
+     */
+    inline: function (textarea, handlers) {
+      handlers = handlers || {};
+      return editor().then(function (CodeMirror) {
+        ensureStylesheet();
+        if (!document.contains(textarea)) return null;  // row already gone
+        var cm = CodeMirror.fromTextArea(textarea, extend(COMMON, {
+          lineNumbers: false,
+          extraKeys: {
+            // Enter is a newline in code, so committing is Ctrl/Cmd+Enter
+            'Ctrl-Enter': function () { if (handlers.onCommit) handlers.onCommit(); },
+            'Cmd-Enter': function () { if (handlers.onCommit) handlers.onCommit(); },
+            'Shift-Ctrl-Enter': function () { if (handlers.onExpand) handlers.onExpand(); },
+            'Shift-Cmd-Enter': function () { if (handlers.onExpand) handlers.onExpand(); },
+            // Tab indents in code; Escape first, then Tab, leaves
+            Esc: function (ed) { ed.getInputField().blur(); },
+          },
+        }));
+        cm.getWrapperElement().classList.add('inspector-cm');
+        cm.setSize('100%', INLINE_HEIGHT);
+        cm.on('blur', function () { if (handlers.onCommit) handlers.onCommit(); });
+        if (handlers.onReady) handlers.onReady(cm);
+        return cm;
+      }).catch(function (e) {
+        // a plain textarea still edits the attribute
+        console.error('Could not attach the code editor: ', e);
+        return null;
+      });
+    },
+
+    /**
+     * The same code, full size, in a modal.
+     *
+     * @param opts  { title, subtitle, value, readOnly, onSave }
+     * @return a function that closes it
+     */
+    open: function (opts) {
+      opts = opts || {};
+      ensureStylesheet();
+      var CodeMirror = null;
+      var overlay = $('<div class="code-modal-overlay"></div>');
+      var box = $('<div class="code-modal" role="dialog" aria-modal="true"></div>');
+      var head = $('<div class="code-modal-head"></div>').append(
+        $('<span class="code-modal-title"></span>').text(opts.title || 'Code'),
+        $('<span class="code-modal-subtitle"></span>').text(opts.subtitle || ''));
+      var body = $('<div class="code-modal-body"></div>');
+      var area = $('<textarea></textarea>').val(opts.value || '');
+      var buttons = $('<div class="code-modal-buttons"></div>');
+      var hint = $('<span class="code-modal-hint"></span>')
+          .text('Ctrl/Cmd+Enter saves, Esc cancels');
+      var cancel = $('<button type="button">Cancel</button>');
+      var save = $('<button type="button" class="primary">Save</button>');
+
+      var opener = document.activeElement;
+      var cm = null;
+
+      function close() {
+        $(document).off('keydown', onKey);
+        overlay.remove();
+        if (opener && opener.focus && document.contains(opener)) opener.focus();
+      }
+      function commit() {
+        var value = cm ? cm.getValue() : area.val();
+        close();
+        if (opts.onSave) opts.onSave(value);
+      }
+      function onKey(event) {
+        if (event.key === 'Escape') { close(); return; }
+        if (event.key !== 'Tab') return;
+        // `aria-modal` has to be true of the behaviour, not just the
+        // attribute: keep Tab inside
+        var items = box.find('button').filter(function () { return !this.disabled; });
+        if (!items.length) return;
+        var first = items.get(0), last = items.get(items.length - 1);
+        var active = document.activeElement;
+        if (!box[0].contains(active)) { event.preventDefault(); first.focus(); }
+        else if (event.shiftKey && active === first) { event.preventDefault(); last.focus(); }
+        else if (!event.shiftKey && active === last) { event.preventDefault(); first.focus(); }
+      }
+
+      cancel.on('click', close);
+      save.on('click', commit);
+      overlay.on('mousedown', function (event) {
+        // the backdrop cancels; the dialog must not
+        if (event.target === overlay[0]) close();
+      });
+
+      box.append(head, body.append(area), buttons.append(hint, cancel, save));
+      overlay.append(box);
+      $(document.body).append(overlay);
+      $(document).on('keydown', onKey);
+
+      // the dialog is usable as a plain textarea until the editor
+      // arrives, rather than showing nothing while it loads
+      area.focus();
+      editor().then(function (CM) {
+        CodeMirror = CM;
+        if (!document.contains(area[0])) return;   // already closed
+        cm = CodeMirror.fromTextArea(area[0], extend(COMMON, {
+          lineNumbers: true,
+          readOnly: !!opts.readOnly,
+          autofocus: true,
+          extraKeys: {
+            'Ctrl-Enter': commit,
+            'Cmd-Enter': commit,
+          },
+        }));
+        cm.setSize('100%', '100%');
+        cm.focus();
+      }).catch(function (e) {
+        // a textarea still edits the attribute
+        console.error('Could not load the code editor: ', e);
+      });
+
+      return close;
+    },
+  };
+});

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -37,6 +37,9 @@ define(['require'], function (require) {
    * sessions never open. Loading it on demand does neither, and the
    * first open costs one fetch of an already-vendored file.
    */
+  // so two dialogs never share a title id
+  var dialogCount = 0;
+
   var pending = null;
   function editor() {
     if (!pending) {
@@ -151,9 +154,14 @@ define(['require'], function (require) {
       ensureStylesheet();
       var CodeMirror = null;
       var overlay = $('<div class="code-modal-overlay"></div>');
-      var box = $('<div class="code-modal" role="dialog" aria-modal="true"></div>');
+      // a dialog announces itself by its heading; without the link a
+      // screen reader reaches an unnamed one
+      var titleId = 'code-modal-title-' + (++dialogCount);
+      var box = $('<div class="code-modal" role="dialog" aria-modal="true"></div>')
+          .attr('aria-labelledby', titleId);
       var head = $('<div class="code-modal-head"></div>').append(
-        $('<span class="code-modal-title"></span>').text(opts.title || 'Code'),
+        $('<span class="code-modal-title"></span>')
+          .attr('id', titleId).text(opts.title || 'Code'),
         $('<span class="code-modal-subtitle"></span>').text(opts.subtitle || ''));
       var body = $('<div class="code-modal-body"></div>');
       var area = $('<textarea></textarea>').val(opts.value || '');

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -1,0 +1,88 @@
+/* The attribute inspector -- see Inspector.js for why it is not a
+   property grid. */
+
+.hfsm-inspector {
+    font-size: 12px;
+    padding: 4px 6px 8px;
+}
+
+.inspector-empty {
+    color: #57606a;
+    font-style: italic;
+    padding: 6px 2px;
+}
+
+.inspector-head {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 2px 0 6px;
+    border-bottom: 1px solid #d0d7de;
+    margin-bottom: 6px;
+}
+.inspector-type { font-weight: 600; }
+.inspector-id {
+    color: #57606a;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.inspector-row {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 6px;
+    align-items: start;
+    margin-bottom: 5px;
+}
+.inspector-label {
+    color: #57606a;
+    text-align: right;
+    padding-top: 3px;
+    margin: 0;
+    font-weight: normal;
+    overflow-wrap: anywhere;
+}
+.inspector-control { min-width: 0; }
+
+.inspector-input {
+    width: 100%;
+    box-sizing: border-box;
+    font: inherit;
+    font-size: 12px;
+    padding: 2px 5px;
+    border: 1px solid #d0d7de;
+    border-radius: 4px;
+    background: #fff;
+}
+.inspector-input:focus {
+    outline: none;
+    border-color: #0969da;
+    box-shadow: 0 0 0 2px rgba(9, 105, 218, .15);
+}
+.inspector-row.kind-checkbox .inspector-input { width: auto; }
+
+/* code is shown as code -- a one-line box for an Entry block is the
+   single worst thing about editing this model in a property grid */
+textarea.inspector-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.4;
+    resize: vertical;
+    white-space: pre;
+    overflow-x: auto;
+}
+
+.inspector-error {
+    color: #cf222e;
+    font-size: 11px;
+    margin-top: 2px;
+    overflow-wrap: anywhere;
+}
+.inspector-row.is-invalid .inspector-input { border-color: #cf222e; }
+
+/* an accepted value with something worth knowing about it -- a name
+   with a space is fine, but it is not what the generator emits */
+.inspector-error.is-note { color: #57606a; }

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -213,3 +213,11 @@ textarea.inspector-prose {
     border-color: #1f883d;
     color: #fff;
 }
+
+/* prose in the pop-out reads as prose: wrapped, and not in a
+   monospace column the width of the screen */
+.code-modal.is-prose .CodeMirror {
+    font-family: inherit;
+    font-size: 14px;
+    line-height: 1.6;
+}

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -75,6 +75,17 @@ textarea.inspector-code {
     overflow-x: auto;
 }
 
+/* markdown, not code: proportional, wrapping, growing with what is
+   written */
+textarea.inspector-prose {
+    font: inherit;
+    font-size: 11px;
+    line-height: 1.45;
+    resize: vertical;
+    white-space: pre-wrap;
+    min-height: 44px;
+}
+
 /* CodeMirror, once it has taken the textarea over. Its height comes
    from CodeEditor.inline via setSize, in pixels: this panel scrolls,
    and an editor sized by its content measures against a width that

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -75,6 +75,43 @@ textarea.inspector-code {
     overflow-x: auto;
 }
 
+/* CodeMirror, once it has taken the textarea over. Its height comes
+   from CodeEditor.inline via setSize, in pixels: this panel scrolls,
+   and an editor sized by its content measures against a width that
+   depends on whether the panel's scrollbar is showing. */
+.inspector-control .CodeMirror.inspector-cm {
+    border: 1px solid #d0d7de;
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.45;
+    background: #fff;
+}
+.inspector-control .CodeMirror.inspector-cm.CodeMirror-focused {
+    border-color: #0969da;
+    box-shadow: 0 0 0 2px rgba(9, 105, 218, .15);
+}
+.inspector-row.is-invalid .CodeMirror.inspector-cm { border-color: #cf222e; }
+
+/* the way out to a bigger editor */
+.inspector-expand {
+    float: right;
+    margin-top: 2px;
+    padding: 0 4px;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #57606a;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.inspector-expand:hover {
+    color: #0969da;
+    border-color: #d0d7de;
+    background: #f6f8fa;
+}
+
 .inspector-error {
     color: #cf222e;
     font-size: 11px;
@@ -86,3 +123,82 @@ textarea.inspector-code {
 /* an accepted value with something worth knowing about it -- a name
    with a space is fine, but it is not what the generator emits */
 .inspector-error.is-note { color: #57606a; }
+
+/* ---- the pop-out code editor ----------------------------------- */
+
+.code-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(27, 31, 36, .5);
+}
+.code-modal {
+    display: flex;
+    flex-direction: column;
+    width: min(980px, 92vw);
+    height: min(680px, 88vh);
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 12px 32px rgba(66, 74, 83, .4);
+    overflow: hidden;
+}
+.code-modal-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 10px 14px;
+    border-bottom: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.code-modal-title { font-weight: 600; font-size: 14px; }
+.code-modal-subtitle {
+    color: #57606a;
+    font-size: 11px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+/* the editor takes whatever is left, rather than the modal growing to
+   fit the code -- a long Entry block should scroll, not push the
+   buttons off the bottom of the screen */
+.code-modal-body { flex: 1 1 auto; min-height: 0; position: relative; }
+.code-modal-body .CodeMirror {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+}
+.code-modal-buttons {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 10px 14px;
+    border-top: 1px solid #d0d7de;
+    background: #f6f8fa;
+}
+.code-modal-hint {
+    margin-right: auto;
+    color: #57606a;
+    font-size: 11px;
+}
+.code-modal-buttons button {
+    font: inherit;
+    font-size: 12px;
+    padding: 5px 14px;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+}
+.code-modal-buttons button.primary {
+    background: #1f883d;
+    border-color: #1f883d;
+    color: #fff;
+}

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -196,6 +196,11 @@ define(['hfsm/viz/describe',
       input = $('<input type="checkbox"/>').prop('checked', !!value);
     } else if (kind === 'number') {
       input = $('<input type="number" step="any"/>').val(value);
+    } else if (kind === 'prose') {
+      // markdown, not C++: a textarea that grows, and no pop-out to a
+      // code editor that would highlight it wrongly
+      input = $('<textarea class="inspector-prose" rows="3"></textarea>').val(value);
+      input.on('input', function () { grow(input); });
     } else if (kind === 'code') {
       // CodeMirror takes this over once it has loaded; until then, and
       // if it fails to, the textarea edits the attribute perfectly well
@@ -243,6 +248,7 @@ define(['hfsm/viz/describe',
     // transaction per character would flood a host's undo stack, and
     // in the playground rewrite the model text under the cursor.
     input.on('change', commit);
+    if (kind === 'prose') input.on('blur', commit);
     if (kind === 'text' || kind === 'code') {
       input.on('blur', commit);
       input.on('keydown', function (event) {
@@ -297,11 +303,20 @@ define(['hfsm/viz/describe',
    * as it builds -- and only for the form that is still showing when
    * the editor finishes loading, since it is fetched on first use.
    */
+  /** size a prose field to its content, up to something sensible */
+  function grow(input) {
+    var el = input[0];
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight + 2, 220) + 'px';
+  }
+
   Inspector.prototype._highlight = function () {
     var self = this;
     var forId = self._id;
     Object.keys(self._fields).forEach(function (name) {
       var field = self._fields[name];
+      if (field.kind === 'prose') { grow(field.input); return; }
       if (field.kind !== 'code' || field.cm) return;
       CodeEditor.inline(field.input[0], {
         onCommit: field.commit,
@@ -354,8 +369,8 @@ define(['hfsm/viz/describe',
    */
   /**
    * The value as it will be stored. Only identifiers are touched:
-   * code and documentation keep every character, including the
-   * trailing newline someone meant to leave.
+   * code and prose keep every character, including the trailing
+   * newline someone meant to leave.
    */
   Inspector.prototype._normalize = function (attr, value) {
     if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return value;
@@ -363,25 +378,24 @@ define(['hfsm/viz/describe',
     return value.trim();
   };
 
+  /**
+   * Why this value cannot be stored, or nothing.
+   *
+   * Every rule comes from `checkModel`, which owns them: a name is
+   * sanitized first unless it is an Event's or a Field's, an End
+   * State may be called "End State", a transition's Event is
+   * verbatim. Restating any of that here is how an editor ends up
+   * refusing what the generator accepts, and accepting what it
+   * refuses -- and the editor's copy is the one nobody generates
+   * from.
+   *
+   * Only identifiers are checked at all. Code is not: it is C++, this
+   * is not a compiler, and refusing what it cannot parse would be
+   * worse than useless.
+   */
   Inspector.prototype._reject = function (attr, value, type) {
     if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return null;
-    var text = String(value == null ? '' : value);
-    // an empty Event means "no trigger", which is a real thing to be;
-    // an empty name is not
-    if (!text) {
-      return attr.name === 'name' ? 'A name is required.' : null;
-    }
-
-    if (attr.name === 'Event') {
-      // a transition's trigger: emitted verbatim, never sanitized
-      return checkModel.isValidString(text) ? null : 'Not a usable C++ name.';
-    }
-    // `name` is not one rule: an Event or a Field name is checked
-    // raw, an End State may be called "End State", everything else is
-    // sanitized first. checkModel owns that -- asking it is what
-    // stops the editor refusing what the generator accepts, and
-    // accepting what it refuses.
-    return checkModel.nameProblem(type, text);
+    return checkModel.identifierProblem(type, attr.name, value);
   };
 
   /**

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -34,8 +34,9 @@
  */
 define(['hfsm/viz/describe',
         'hfsm/checkModel',
+        './CodeEditor',
         'css!./Inspector.css'],
-       function (describe, checkModel) {
+       function (describe, checkModel, CodeEditor) {
   'use strict';
 
   function Inspector() {
@@ -59,7 +60,7 @@ define(['hfsm/viz/describe',
 
   Inspector.prototype.clear = function () {
     this._id = null;
-    this._fields = {};
+    this._release();
     if (this._el) {
       this._el.empty().append(
         $('<div class="inspector-empty"></div>')
@@ -71,6 +72,16 @@ define(['hfsm/viz/describe',
   Inspector.prototype.hasFocus = function () {
     return !!(this._el && this._el.length &&
               this._el[0].contains(document.activeElement));
+  };
+
+  /** detach the editors before the elements holding them go */
+  Inspector.prototype._release = function () {
+    var self = this;
+    Object.keys(self._fields).forEach(function (name) {
+      var cm = self._fields[name].cm;
+      if (cm) { try { cm.toTextArea(); } catch (e) { /* already gone */ } }
+    });
+    self._fields = {};
   };
 
   /**
@@ -95,10 +106,15 @@ define(['hfsm/viz/describe',
 
     Object.keys(self._fields).forEach(function (name) {
       var field = self._fields[name];
+      var v = valueOf(node, field.attr);
+      if (field.cm) {
+        if (field.cm.hasFocus()) return;
+        if (field.cm.getValue() !== String(v)) field.cm.setValue(String(v));
+        return;
+      }
       if (field.input[0] === document.activeElement) return;
-      var value = valueOf(node, field.attr);
-      if (field.kind === 'checkbox') field.input.prop('checked', !!value);
-      else if (field.input.val() !== String(value)) field.input.val(value);
+      if (field.kind === 'checkbox') field.input.prop('checked', !!v);
+      else if (field.input.val() !== String(v)) field.input.val(v);
     });
   };
 
@@ -119,7 +135,7 @@ define(['hfsm/viz/describe',
     }
 
     self._id = id;
-    self._fields = {};
+    self._release();
     self._el.empty();
 
     var readOnly = backend.isReadOnly();
@@ -133,7 +149,7 @@ define(['hfsm/viz/describe',
       fields.append(self._renderField(id, attr, node, readOnly));
     });
     self._el.append(fields);
-    self._grow();
+    self._highlight();
   };
 
   /** the value a node currently has for `attr`, or its default */
@@ -158,9 +174,10 @@ define(['hfsm/viz/describe',
     } else if (kind === 'number') {
       input = $('<input type="number" step="any"/>').val(value);
     } else if (kind === 'code') {
+      // CodeMirror takes this over once it has loaded; until then, and
+      // if it fails to, the textarea edits the attribute perfectly well
       input = $('<textarea class="inspector-code" spellcheck="false" ' +
-                'rows="2"></textarea>').val(value);
-      input.on('input', function () { fit(input); });
+                'rows="3"></textarea>').val(value);
     } else {
       input = $('<input type="text"/>').val(value);
     }
@@ -168,10 +185,11 @@ define(['hfsm/viz/describe',
     if (readOnly) input.prop('disabled', true);
 
     var error = $('<div class="inspector-error"></div>').hide();
-    self._fields[attr.name] = { input: input, kind: kind, attr: attr, row: row };
+    var field = { input: input, kind: kind, attr: attr, row: row, cm: null };
+    self._fields[attr.name] = field;
 
     function commit() {
-      var next = readValue(input, kind);
+      var next = readValue(field);
       var problem = self._reject(attr, next);
       if (problem) {
         error.text(problem).show().removeClass('is-note');
@@ -185,49 +203,102 @@ define(['hfsm/viz/describe',
       self._write(id, attr, next);
     }
 
+    field.commit = commit;
+
     // Commit when the field is done, not on every keystroke: a
     // transaction per character would flood a host's undo stack, and
     // in the playground rewrite the model text under the cursor.
     input.on('change', commit);
-    if (kind === 'code' || kind === 'text') {
+    if (kind === 'text' || kind === 'code') {
       input.on('blur', commit);
-      // Enter commits a one-line field; a code block needs it for
-      // newlines, so there it is Ctrl/Cmd+Enter
       input.on('keydown', function (event) {
         if (event.key !== 'Enter') return;
-        if (kind === 'text' || event.ctrlKey || event.metaKey) {
+        // Enter commits a one-line field; in code it is a newline, so
+        // there it is Ctrl/Cmd+Enter -- and Shift+Ctrl/Cmd+Enter opens
+        // the big editor
+        if (kind === 'text') {
           event.preventDefault();
           commit();
+        } else if (event.ctrlKey || event.metaKey) {
+          event.preventDefault();
+          if (event.shiftKey) self._expand(id, attr);
+          else commit();
         }
       });
     }
 
-    return row.append(label, $('<div class="inspector-control"></div>')
-                      .append(input, error));
+    var control = $('<div class="inspector-control"></div>').append(input, error);
+    if (kind === 'code') {
+      // 250px of column is not where anyone wants to write a state's
+      // Entry block
+      var expand = $('<button type="button" class="inspector-expand" ' +
+                     'title="Edit in a larger editor (Shift+Ctrl/Cmd+Enter)" ' +
+                     'aria-label="Edit ' + attr.name + ' in a larger editor">' +
+                     '\u2921</button>');
+      expand.on('click', function () { self._expand(id, attr); });
+      control.append(expand);
+      field.expand = function () { self._expand(id, attr); };
+    }
+
+    return row.append(label, control);
   };
 
-  function readValue(input, kind) {
-    if (kind === 'checkbox') return input.is(':checked');
-    if (kind === 'number') {
-      var n = parseFloat(input.val());
+  function readValue(field) {
+    if (field.kind === 'checkbox') return field.input.is(':checked');
+    if (field.kind === 'number') {
+      var n = parseFloat(field.input.val());
       return isNaN(n) ? 0 : n;
     }
-    return input.val();
+    // once CodeMirror has taken the textarea over, it holds the text
+    if (field.cm) return field.cm.getValue();
+    return field.input.val();
   }
 
-  /** grow a code field to its content, up to something sensible */
-  function fit(input) {
-    var el = input[0];
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = Math.min(el.scrollHeight + 2, 260) + 'px';
-  }
-
-  /** size every code field once the form is in the document */
-  Inspector.prototype._grow = function () {
+  /**
+   * Hand every code field to CodeMirror.
+   *
+   * Only once the form is in the document -- `fromTextArea` measures
+   * as it builds -- and only for the form that is still showing when
+   * the editor finishes loading, since it is fetched on first use.
+   */
+  Inspector.prototype._highlight = function () {
     var self = this;
+    var forId = self._id;
     Object.keys(self._fields).forEach(function (name) {
-      if (self._fields[name].kind === 'code') fit(self._fields[name].input);
+      var field = self._fields[name];
+      if (field.kind !== 'code' || field.cm) return;
+      CodeEditor.inline(field.input[0], {
+        onCommit: field.commit,
+        onExpand: field.expand,
+        onReady: function (cm) {
+          if (self._id !== forId) { cm.toTextArea(); return; }  // moved on
+          field.cm = cm;
+          if (self._backend.isReadOnly()) cm.setOption('readOnly', true);
+        },
+      });
+    });
+  };
+
+  /**
+   * The same attribute, in an editor with room to work in. What is
+   * saved goes back through the same commit path as the inline field,
+   * so there is one place that validates and writes.
+   */
+  Inspector.prototype._expand = function (id, attr) {
+    var self = this;
+    var field = self._fields[attr.name];
+    if (!field) return;
+    var node = self._backend.getNode(id);
+    CodeEditor.open({
+      title: attr.name,
+      subtitle: (node && node.name ? node.name + '  ' : '') + id,
+      value: readValue(field),
+      readOnly: self._backend.isReadOnly(),
+      onSave: function (value) {
+        if (field.cm) field.cm.setValue(value);
+        else field.input.val(value);
+        field.commit();
+      },
     });
   };
 

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -248,7 +248,17 @@ define(['hfsm/viz/describe',
     // transaction per character would flood a host's undo stack, and
     // in the playground rewrite the model text under the cursor.
     input.on('change', commit);
-    if (kind === 'prose') input.on('blur', commit);
+    if (kind === 'prose') {
+      input.on('blur', commit);
+      input.on('keydown', function (event) {
+        // Enter is a newline in prose; the modifier opens the big one
+        if (event.key === 'Enter' && event.shiftKey &&
+            (event.ctrlKey || event.metaKey)) {
+          event.preventDefault();
+          self._expand(id, attr);
+        }
+      });
+    }
     if (kind === 'text' || kind === 'code') {
       input.on('blur', commit);
       input.on('keydown', function (event) {
@@ -268,9 +278,9 @@ define(['hfsm/viz/describe',
     }
 
     var control = $('<div class="inspector-control"></div>').append(input, error);
-    if (kind === 'code') {
+    if (kind === 'code' || kind === 'prose') {
       // 250px of column is not where anyone wants to write a state's
-      // Entry block
+      // Entry block -- nor a page of documentation
       var expand = $('<button type="button" class="inspector-expand" ' +
                      'title="Edit in a larger editor (Shift+Ctrl/Cmd+Enter)" ' +
                      'aria-label="Edit ' + attr.name + ' in a larger editor">' +
@@ -345,9 +355,11 @@ define(['hfsm/viz/describe',
       subtitle: (node && node.name ? node.name + '  ' : '') + id,
       value: readValue(field),
       readOnly: self._backend.isReadOnly(),
+      prose: field.kind === 'prose',
       onSave: function (value) {
         if (field.cm) field.cm.setValue(value);
         else field.input.val(value);
+        if (field.kind === 'prose') grow(field.input);
         field.commit();
       },
     });

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -145,7 +145,7 @@ define(['hfsm/viz/describe',
         $('<span class="inspector-id"></span>').text(id)));
 
     var fields = $('<div class="inspector-fields"></div>');
-    describe.fieldOrder(schema.attributes).forEach(function (attr) {
+    describe.editableAttributes(schema).forEach(function (attr) {
       fields.append(self._renderField(id, attr, node, readOnly));
     });
     self._el.append(fields);

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -166,7 +166,12 @@ define(['hfsm/viz/describe',
     var value = valueOf(node, attr);
 
     var row = $('<div class="inspector-row"></div>').addClass('kind-' + kind);
-    var label = $('<label class="inspector-label"></label>').text(attr.name);
+    // `for`/`id`, so a screen reader reads the field by its attribute
+    // and clicking the label puts the caret in it
+    var fieldId = 'insp-' + String(id).replace(/\W/g, '-') + '-' +
+        attr.name.replace(/\W/g, '-');
+    var label = $('<label class="inspector-label"></label>')
+        .text(attr.name).attr('for', fieldId);
     var input;
 
     if (kind === 'checkbox') {
@@ -181,7 +186,7 @@ define(['hfsm/viz/describe',
     } else {
       input = $('<input type="text"/>').val(value);
     }
-    input.addClass('inspector-input');
+    input.addClass('inspector-input').attr('id', fieldId);
     if (readOnly) input.prop('disabled', true);
 
     var error = $('<div class="inspector-error"></div>').hide();
@@ -189,7 +194,17 @@ define(['hfsm/viz/describe',
     self._fields[attr.name] = field;
 
     function commit() {
-      var next = readValue(field);
+      // What is validated must be what is STORED. Validating a
+      // trimmed copy and writing the original let " GO " through as a
+      // valid `GO`, and `checkModel.checkEvent` -- which does not
+      // trim -- then rejected the model the inspector exists to keep
+      // valid. For an identifier the surrounding space was never
+      // meant, so the trimmed value is what gets written.
+      var next = self._normalize(attr, readValue(field));
+      if (next !== readValue(field) && field.kind !== 'checkbox') {
+        if (field.cm) field.cm.setValue(String(next));
+        else field.input.val(next);
+      }
       var problem = self._reject(attr, next);
       if (problem) {
         error.text(problem).show().removeClass('is-note');
@@ -316,9 +331,20 @@ define(['hfsm/viz/describe',
    * is not a compiler, and refusing what it cannot parse would be
    * worse than useless.
    */
+  /**
+   * The value as it will be stored. Only identifiers are touched:
+   * code and documentation keep every character, including the
+   * trailing newline someone meant to leave.
+   */
+  Inspector.prototype._normalize = function (attr, value) {
+    if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return value;
+    if (typeof value !== 'string') return value;
+    return value.trim();
+  };
+
   Inspector.prototype._reject = function (attr, value) {
     if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return null;
-    var text = String(value == null ? '' : value).trim();
+    var text = String(value == null ? '' : value);
     // an empty Event means "no trigger", which is a real thing to be;
     // an empty name is not
     if (!text) {
@@ -341,7 +367,7 @@ define(['hfsm/viz/describe',
    */
   Inspector.prototype._note = function (attr, value) {
     if (attr.name !== 'name') return null;
-    var text = String(value == null ? '' : value).trim();
+    var text = String(value == null ? '' : value);
     var asGenerated = checkModel.sanitizeString(text);
     return asGenerated === text ? null : 'Generated as ' + asGenerated;
   };

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -74,6 +74,17 @@ define(['hfsm/viz/describe',
               this._el[0].contains(document.activeElement));
   };
 
+  /** enable or disable every control in one place */
+  Inspector.prototype._setReadOnly = function (readOnly) {
+    var self = this;
+    Object.keys(self._fields).forEach(function (name) {
+      var field = self._fields[name];
+      field.input.prop('disabled', !!readOnly);
+      if (field.cm) field.cm.setOption('readOnly', !!readOnly);
+      if (field.expandBtn) field.expandBtn.prop('disabled', !!readOnly);
+    });
+  };
+
   /** detach the editors before the elements holding them go */
   Inspector.prototype._release = function () {
     var self = this;
@@ -103,6 +114,13 @@ define(['hfsm/viz/describe',
     if (!self._id) return;
     var node = self._backend.getNode(self._id);
     if (!node) return self.clear();
+
+    // Read-only is a property of the BRANCH, and that changes under a
+    // selection that does not: going to a read-only branch used to
+    // leave the form editable, and coming back from one used to leave
+    // it disabled, because it was only ever read when the form was
+    // built.
+    self._setReadOnly(self._backend.isReadOnly());
 
     Object.keys(self._fields).forEach(function (name) {
       var field = self._fields[name];
@@ -146,7 +164,7 @@ define(['hfsm/viz/describe',
 
     var fields = $('<div class="inspector-fields"></div>');
     describe.editableAttributes(schema).forEach(function (attr) {
-      fields.append(self._renderField(id, attr, node, readOnly));
+      fields.append(self._renderField(id, attr, node, readOnly, schema.name));
     });
     self._el.append(fields);
     self._highlight();
@@ -160,7 +178,7 @@ define(['hfsm/viz/describe',
     return value;
   }
 
-  Inspector.prototype._renderField = function (id, attr, node, readOnly) {
+  Inspector.prototype._renderField = function (id, attr, node, readOnly, type) {
     var self = this;
     var kind = describe.fieldKind(attr);
     var value = valueOf(node, attr);
@@ -190,7 +208,8 @@ define(['hfsm/viz/describe',
     if (readOnly) input.prop('disabled', true);
 
     var error = $('<div class="inspector-error"></div>').hide();
-    var field = { input: input, kind: kind, attr: attr, row: row, cm: null };
+    var field = { input: input, kind: kind, attr: attr, row: row, cm: null,
+                  type: type };
     self._fields[attr.name] = field;
 
     function commit() {
@@ -205,14 +224,14 @@ define(['hfsm/viz/describe',
         if (field.cm) field.cm.setValue(String(next));
         else field.input.val(next);
       }
-      var problem = self._reject(attr, next);
+      var problem = self._reject(attr, next, type);
       if (problem) {
         error.text(problem).show().removeClass('is-note');
         row.addClass('is-invalid');
         return;
       }
       row.removeClass('is-invalid');
-      var note = self._note(attr, next);
+      var note = self._note(attr, next, type);
       if (note) error.text(note).addClass('is-note').show();
       else error.hide();
       self._write(id, attr, next);
@@ -251,8 +270,10 @@ define(['hfsm/viz/describe',
                      'aria-label="Edit ' + attr.name + ' in a larger editor">' +
                      '\u2921</button>');
       expand.on('click', function () { self._expand(id, attr); });
+      if (readOnly) expand.prop('disabled', true);
       control.append(expand);
       field.expand = function () { self._expand(id, attr); };
+      field.expandBtn = expand;
     }
 
     return row.append(label, control);
@@ -342,7 +363,7 @@ define(['hfsm/viz/describe',
     return value.trim();
   };
 
-  Inspector.prototype._reject = function (attr, value) {
+  Inspector.prototype._reject = function (attr, value, type) {
     if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return null;
     var text = String(value == null ? '' : value);
     // an empty Event means "no trigger", which is a real thing to be;
@@ -351,13 +372,16 @@ define(['hfsm/viz/describe',
       return attr.name === 'name' ? 'A name is required.' : null;
     }
 
-    var asGenerated = attr.name === 'name' ? checkModel.sanitizeString(text) : text;
-    if (!checkModel.isValidString(asGenerated)) {
-      // short on purpose: the panel is narrow, and a paragraph here
-      // wraps to eight lines and pushes the rest of the form off
-      return 'Not a usable C++ name.';
+    if (attr.name === 'Event') {
+      // a transition's trigger: emitted verbatim, never sanitized
+      return checkModel.isValidString(text) ? null : 'Not a usable C++ name.';
     }
-    return null;
+    // `name` is not one rule: an Event or a Field name is checked
+    // raw, an End State may be called "End State", everything else is
+    // sanitized first. checkModel owns that -- asking it is what
+    // stops the editor refusing what the generator accepts, and
+    // accepting what it refuses.
+    return checkModel.nameProblem(type, text);
   };
 
   /**
@@ -365,8 +389,10 @@ define(['hfsm/viz/describe',
    * space in it is fine, but it is not what appears in the generated
    * code, and nothing else in the tool ever mentions that.
    */
-  Inspector.prototype._note = function (attr, value) {
-    if (attr.name !== 'name') return null;
+  Inspector.prototype._note = function (attr, value, type) {
+    // only where the name IS sanitized: an Event or a Field name is
+    // emitted exactly as typed, so there is nothing to report
+    if (attr.name !== 'name' || type === 'Event' || type === 'Field') return null;
     var text = String(value == null ? '' : value);
     var asGenerated = checkModel.sanitizeString(text);
     return asGenerated === text ? null : 'Generated as ' + asGenerated;

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -1,0 +1,299 @@
+/**
+ * The selected node's attributes, editable in place.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * You cannot get far editing a machine from the diagram alone. A
+ * state dropped from the palette is called "State", a transition has
+ * no event, and a second of either collides -- so without a way to
+ * type a name, an Event, a Guard or an Entry block, the next thing
+ * you build is an invalid model.
+ *
+ * WebGME answers this with its Property Editor, which is part of the
+ * application rather than of the visualizer, so it did not come
+ * across with the widget. It is also the least pleasant part of
+ * modelling with the tool: a generic grid, sorted alphabetically,
+ * with C++ in one-line cells and nothing wrong until generation
+ * fails.
+ *
+ * So this is deliberately not a property grid:
+ *
+ *  - fields are ordered by what the machine DOES -- name, Event,
+ *    Guard, Action, Entry/Exit/Tick -- with the rarely-touched
+ *    declarations last (`describe.fieldOrder`);
+ *  - code is rendered as code, in a textarea that grows
+ *    (`describe.fieldKind`);
+ *  - a name or an Event that is not a C++ identifier is refused as it
+ *    is typed, with the reason, instead of reaching the generator --
+ *    or, in the Event case, the simulator, which says so with a
+ *    modal;
+ *  - it sits beside the diagram and follows the selection.
+ *
+ * Every change is one transaction, so it is one undo in a host that
+ * has undo.
+ */
+define(['hfsm/viz/describe',
+        'hfsm/checkModel',
+        'css!./Inspector.css'],
+       function (describe, checkModel) {
+  'use strict';
+
+  function Inspector() {
+    this._el = null;
+    this._backend = null;
+    this._id = null;
+    this._fields = {};   // attribute name -> the row it is rendered as
+  }
+
+  /**
+   * @param container  where to draw
+   * @param backend    a ModelBackend -- the only thing written through
+   */
+  Inspector.prototype.initialize = function (container, backend) {
+    this._el = $(container);
+    this._backend = backend;
+    this._id = null;
+    this._el.addClass('hfsm-inspector');
+    this.clear();
+  };
+
+  Inspector.prototype.clear = function () {
+    this._id = null;
+    this._fields = {};
+    if (this._el) {
+      this._el.empty().append(
+        $('<div class="inspector-empty"></div>')
+          .text('Select a state or transition to edit it.'));
+    }
+  };
+
+  /** whoever the user is currently typing into, if it is one of ours */
+  Inspector.prototype.hasFocus = function () {
+    return !!(this._el && this._el.length &&
+              this._el[0].contains(document.activeElement));
+  };
+
+  /**
+   * Re-read the shown node after a model change.
+   *
+   * Values are written into the fields that are already there rather
+   * than the form being rebuilt. Almost every change here is the
+   * user's OWN edit committing, and rebuilding would destroy the
+   * inputs mid-interaction: tab out of `name` and the field you just
+   * tabbed INTO is replaced under the caret. The form is only rebuilt
+   * when the node it describes is a different one.
+   *
+   * A field with the focus is left alone entirely -- it is being
+   * typed into, and what is in the store is what the typing is on its
+   * way to becoming.
+   */
+  Inspector.prototype.refresh = function () {
+    var self = this;
+    if (!self._id) return;
+    var node = self._backend.getNode(self._id);
+    if (!node) return self.clear();
+
+    Object.keys(self._fields).forEach(function (name) {
+      var field = self._fields[name];
+      if (field.input[0] === document.activeElement) return;
+      var value = valueOf(node, field.attr);
+      if (field.kind === 'checkbox') field.input.prop('checked', !!value);
+      else if (field.input.val() !== String(value)) field.input.val(value);
+    });
+  };
+
+  Inspector.prototype.show = function (id) {
+    var self = this;
+    if (!self._el) return;
+    if (!id) return self.clear();
+
+    var backend = self._backend;
+    var schema = backend.getNodeSchema(id);
+    var node = backend.getNode(id);
+    if (!schema || !node) return self.clear();
+
+    // nothing to rebuild if it is the same node: refresh() keeps its
+    // values current, and rebuilding would throw away the focus
+    if (self._id === id && Object.keys(self._fields).length) {
+      return self.refresh();
+    }
+
+    self._id = id;
+    self._fields = {};
+    self._el.empty();
+
+    var readOnly = backend.isReadOnly();
+    self._el.append(
+      $('<div class="inspector-head"></div>').append(
+        $('<span class="inspector-type"></span>').text(schema.name),
+        $('<span class="inspector-id"></span>').text(id)));
+
+    var fields = $('<div class="inspector-fields"></div>');
+    describe.fieldOrder(schema.attributes).forEach(function (attr) {
+      fields.append(self._renderField(id, attr, node, readOnly));
+    });
+    self._el.append(fields);
+    self._grow();
+  };
+
+  /** the value a node currently has for `attr`, or its default */
+  function valueOf(node, attr) {
+    var value = node[attr.name];
+    if (value === undefined || value === null) value = attr.defaultValue;
+    if (value === undefined || value === null) value = '';
+    return value;
+  }
+
+  Inspector.prototype._renderField = function (id, attr, node, readOnly) {
+    var self = this;
+    var kind = describe.fieldKind(attr);
+    var value = valueOf(node, attr);
+
+    var row = $('<div class="inspector-row"></div>').addClass('kind-' + kind);
+    var label = $('<label class="inspector-label"></label>').text(attr.name);
+    var input;
+
+    if (kind === 'checkbox') {
+      input = $('<input type="checkbox"/>').prop('checked', !!value);
+    } else if (kind === 'number') {
+      input = $('<input type="number" step="any"/>').val(value);
+    } else if (kind === 'code') {
+      input = $('<textarea class="inspector-code" spellcheck="false" ' +
+                'rows="2"></textarea>').val(value);
+      input.on('input', function () { fit(input); });
+    } else {
+      input = $('<input type="text"/>').val(value);
+    }
+    input.addClass('inspector-input');
+    if (readOnly) input.prop('disabled', true);
+
+    var error = $('<div class="inspector-error"></div>').hide();
+    self._fields[attr.name] = { input: input, kind: kind, attr: attr, row: row };
+
+    function commit() {
+      var next = readValue(input, kind);
+      var problem = self._reject(attr, next);
+      if (problem) {
+        error.text(problem).show().removeClass('is-note');
+        row.addClass('is-invalid');
+        return;
+      }
+      row.removeClass('is-invalid');
+      var note = self._note(attr, next);
+      if (note) error.text(note).addClass('is-note').show();
+      else error.hide();
+      self._write(id, attr, next);
+    }
+
+    // Commit when the field is done, not on every keystroke: a
+    // transaction per character would flood a host's undo stack, and
+    // in the playground rewrite the model text under the cursor.
+    input.on('change', commit);
+    if (kind === 'code' || kind === 'text') {
+      input.on('blur', commit);
+      // Enter commits a one-line field; a code block needs it for
+      // newlines, so there it is Ctrl/Cmd+Enter
+      input.on('keydown', function (event) {
+        if (event.key !== 'Enter') return;
+        if (kind === 'text' || event.ctrlKey || event.metaKey) {
+          event.preventDefault();
+          commit();
+        }
+      });
+    }
+
+    return row.append(label, $('<div class="inspector-control"></div>')
+                      .append(input, error));
+  };
+
+  function readValue(input, kind) {
+    if (kind === 'checkbox') return input.is(':checked');
+    if (kind === 'number') {
+      var n = parseFloat(input.val());
+      return isNaN(n) ? 0 : n;
+    }
+    return input.val();
+  }
+
+  /** grow a code field to its content, up to something sensible */
+  function fit(input) {
+    var el = input[0];
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight + 2, 260) + 'px';
+  }
+
+  /** size every code field once the form is in the document */
+  Inspector.prototype._grow = function () {
+    var self = this;
+    Object.keys(self._fields).forEach(function (name) {
+      if (self._fields[name].kind === 'code') fit(self._fields[name].input);
+    });
+  };
+
+  /**
+   * Why this value cannot be stored, or nothing.
+   *
+   * The rule is exactly `checkModel`'s, per attribute, because being
+   * stricter here would refuse models the generator is perfectly
+   * happy with: `checkName` SANITIZES first -- spaces and hyphens
+   * become underscores -- so "State 1" is a fine name and every
+   * existing model uses names like it. `checkEvent` does not
+   * sanitize, so an event name really must be an identifier already.
+   *
+   * Only identifiers are checked at all. Code is not: it is C++, this
+   * is not a compiler, and refusing what it cannot parse would be
+   * worse than useless.
+   */
+  Inspector.prototype._reject = function (attr, value) {
+    if (describe.IDENTIFIER_ATTRIBUTES.indexOf(attr.name) === -1) return null;
+    var text = String(value == null ? '' : value).trim();
+    // an empty Event means "no trigger", which is a real thing to be;
+    // an empty name is not
+    if (!text) {
+      return attr.name === 'name' ? 'A name is required.' : null;
+    }
+
+    var asGenerated = attr.name === 'name' ? checkModel.sanitizeString(text) : text;
+    if (!checkModel.isValidString(asGenerated)) {
+      // short on purpose: the panel is narrow, and a paragraph here
+      // wraps to eight lines and pushes the rest of the form off
+      return 'Not a usable C++ name.';
+    }
+    return null;
+  };
+
+  /**
+   * Something worth saying about an accepted value. A name with a
+   * space in it is fine, but it is not what appears in the generated
+   * code, and nothing else in the tool ever mentions that.
+   */
+  Inspector.prototype._note = function (attr, value) {
+    if (attr.name !== 'name') return null;
+    var text = String(value == null ? '' : value).trim();
+    var asGenerated = checkModel.sanitizeString(text);
+    return asGenerated === text ? null : 'Generated as ' + asGenerated;
+  };
+
+  Inspector.prototype._write = function (id, attr, value) {
+    var self = this;
+    var backend = self._backend;
+    if (value === backend.getAttribute(id, attr.name)) return;  // nothing to do
+    try {
+      backend.transact('Set ' + attr.name + ' on ' + id, function () {
+        backend.setAttribute(id, attr.name, value);
+      }, function (err) {
+        if (err) {
+          console.error('Could not set ' + attr.name + ': ', err);
+          self.refresh();   // put back what the store actually holds
+        }
+      });
+    } catch (e) {
+      // transact reports through the callback and rethrows; the
+      // report is enough, and letting it escape a change handler
+      // raises the host's uncaught-exception banner over it
+    }
+  };
+
+  return Inspector;
+});

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.html
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.html
@@ -21,7 +21,9 @@
   <div id="simulatorHandle" class="ui-layout-resizer ui-draggable-handle ui-layout-resizer-open">
   </div>
   <div class="simulator-bottom-panel">
-    <div class="stateInfoTitle">Selected State:
+    <div class="stateInfoTitle">Selected:
+    </div>
+    <div id="nodeInspector">
     </div>
     <div id="stateInfo">
     </div>

--- a/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
+++ b/src/visualizers/widgets/HFSMViz/Simulator/Simulator.js
@@ -6,6 +6,7 @@ define(['q',
         'underscore',
         './Choice',
         './FormDialog',
+        '../Inspector/Inspector',
         'hfsm/declParser',
         'hfsm/checkModel',
         'bower/mustache.js/mustache.min',
@@ -18,6 +19,7 @@ define(['q',
                 _,
                 Choice,
                 FormDialog,
+                Inspector,
                 declParser,
                 checkModel,
                 mustache,
@@ -144,6 +146,12 @@ define(['q',
 
            // STATE INFO DISPLAY
            self._stateInfo = self._el.find('#stateInfo').first();
+
+           // ATTRIBUTE INSPECTOR -- the selected node's own fields,
+           // above the UML preview of it
+           self._inspector = new Inspector();
+           self._inspector.initialize(
+             self._el.find('#nodeInspector').first(), backend);
 
            // Active state information
            self._activeState = null;
@@ -802,6 +810,10 @@ define(['q',
 
          Simulator.prototype.update = function() {
            var self = this;
+           // the shown node may have just changed underneath us --
+           // refresh() leaves it alone while it has the focus, which
+           // is exactly when the change was the user's own typing
+           if (self._inspector) self._inspector.refresh();
            self.updateEventButtons();
            self.updateVariablesPanel();
            self.updateEventDefsPanel();
@@ -1707,6 +1719,19 @@ define(['q',
                  .on('click', self.onClickStateInfo.bind(self) );
              }
            }
+         };
+
+         /**
+          * Show a node's own attributes for editing. Separate from
+          * displayStateInfo, which walks UP the parent chain to draw
+          * the containing states -- there is one selection, and it is
+          * the node that was clicked.
+          */
+         Simulator.prototype.showInspector = function( gmeId ) {
+           var self = this;
+           if (!self._inspector) return;
+           if (gmeId) self._inspector.show( gmeId );
+           else self._inspector.clear();
          };
 
          Simulator.prototype.hideStateInfo = function( ) {

--- a/src/visualizers/widgets/HFSMViz/WebGMEBackend.js
+++ b/src/visualizers/widgets/HFSMViz/WebGMEBackend.js
@@ -88,30 +88,51 @@ define([
 
   // what a "create a child here" form needs: the creatable types
   // under `parentId` and, for each, its attributes
+  /** everything a form needs about one meta node */
+  function schemaOfMeta(client, metaId) {
+    var meta = client.getNode(metaId);
+    if (!meta || meta.isAbstract()) return null;
+    return {
+      name: meta.getAttribute('name'),
+      typeId: metaId,
+      isConnection: meta.isConnection(),
+      attributes: meta.getAttributeNames().sort().map(function (attr) {
+        var attrMeta = meta.getAttributeMeta(attr) || {};
+        return {
+          name: attr,
+          type: attrMeta.type,
+          // the meta node's own value IS the default an instance
+          // starts with (getAttributeMeta carries the type, not a
+          // default)
+          defaultValue: meta.getAttribute(attr),
+        };
+      }),
+    };
+  }
+
+  /**
+   * What THIS node's type declares. Asked of the node's own meta
+   * type, so -- unlike getChildTypeSchemas -- it is not filtered by
+   * what the parent could still contain: whether another Initial
+   * could be created says nothing about editing the one that is
+   * already there.
+   */
+  WebGMEBackend.prototype.getNodeSchema = function (id) {
+    var client = this._client;
+    var node = client.getNode(id);
+    if (!node) return null;
+    return schemaOfMeta(client, node.getMetaTypeId());
+  };
+
   WebGMEBackend.prototype.getChildTypeSchemas = function (parentId) {
     var client = this._client;
     var node = client.getNode(parentId);
     if (!node) return [];
     var valid = node.getValidChildrenTypesDetailed();
     return Object.keys(valid).map(function (metaId) {
-      var meta = client.getNode(metaId);
-      if (!meta || !valid[metaId] || meta.isAbstract()) return null;
-      return {
-        name: meta.getAttribute('name'),
-        typeId: metaId,
-        isConnection: meta.isConnection(),
-        attributes: meta.getAttributeNames().sort().map(function (attr) {
-          var attrMeta = meta.getAttributeMeta(attr) || {};
-          return {
-            name: attr,
-            type: attrMeta.type,
-            // the meta node's own value IS the default an instance
-            // starts with (getAttributeMeta carries the type, not a
-            // default)
-            defaultValue: meta.getAttribute(attr),
-          };
-        }),
-      };
+      // `valid[metaId]` false means one is allowed but no MORE of
+      // them; a create form must not offer it
+      return valid[metaId] ? schemaOfMeta(client, metaId) : null;
     }).filter(Boolean);
   };
 

--- a/test/generator.spec.js
+++ b/test/generator.spec.js
@@ -83,6 +83,8 @@ function expectResolveError(fixtureName, mutate, errRegex) {
   }, 'expected error matching ' + errRegex);
 }
 
+
+
 describe('hfsm generator', function() {
 
   before(function() {
@@ -930,6 +932,52 @@ describe('hfsm generator', function() {
           var expected = fs.readFileSync(path.join(goldenDir, fname), 'utf8');
           assert.strictEqual(artifacts[fname], expected,
                              'generated ' + fname + ' differs from golden');
+        });
+      });
+    });
+  });
+
+  describe('checkModel.nameProblem', function() {
+    // The editor refuses names through this so that it refuses exactly
+    // what the checker refuses. These assertions are the contract
+    // between them.
+
+    it('sanitizes most names before judging them', function() {
+      assert.strictEqual(mods.checkModel.nameProblem('State', 'State 1'), null);
+      assert.strictEqual(mods.checkModel.nameProblem('State', 'Wait-For-Ack'), null);
+      assert.ok(mods.checkModel.nameProblem('State', '2fast'));
+      assert.ok(mods.checkModel.nameProblem('State', 'class'));
+    });
+
+    it('judges an Event or Field name exactly as typed', function() {
+      // emitted verbatim, so sanitizing here would accept a name the
+      // generator cannot use
+      assert.ok(mods.checkModel.nameProblem('Event', 'BUTTON-PRESS'));
+      assert.strictEqual(mods.checkModel.nameProblem('Event', 'BUTTON_PRESS'), null);
+      assert.ok(mods.checkModel.nameProblem('Field', 'val 1'));
+      assert.strictEqual(mods.checkModel.nameProblem('Field', 'val_1'), null);
+    });
+
+    it('lets an End State be called End State, and nothing else be',
+       function() {
+         assert.strictEqual(mods.checkModel.nameProblem('End State', 'End State'), null);
+         assert.strictEqual(mods.checkModel.nameProblem('End State', 'End_State'), null);
+         assert.ok(mods.checkModel.nameProblem('State', 'End State'),
+                   'a State may not generate the reserved End_State');
+         assert.ok(mods.checkModel.nameProblem('End State', 'class'));
+       });
+
+    it('agrees with the checks the checker actually runs', function() {
+      // every name in every fixture passes, or the fixtures would not
+      // generate
+      ['basic', 'features', 'payloads'].forEach(function(name) {
+        var model = processFixture(name);
+        Object.keys(model.objects).forEach(function(p) {
+          var obj = model.objects[p];
+          if (!obj.name || obj.type === 'Project') return;
+          assert.strictEqual(mods.checkModel.nameProblem(obj.type, obj.name), null,
+                             name + ' ' + p + ' (' + obj.type + ') named "' +
+                             obj.name + '" should be accepted');
         });
       });
     });

--- a/test/localBackend.spec.js
+++ b/test/localBackend.spec.js
@@ -104,6 +104,60 @@ describe('LocalBackend', function() {
         backend.getValidConnectionTypes(ids.event, ids.state, '/p/m'), []);
     });
 
+    it('describes an existing node by its own type', function() {
+      var backend = LocalBackend(emptyModel());
+      var id;
+      backend.transact('add', function() {
+        id = backend.createChild('/p/m', 'State');
+      });
+      var schema = backend.getNodeSchema(id);
+      assert.strictEqual(schema.name, 'State');
+      assert.strictEqual(schema.isConnection, false);
+      var byName = {};
+      schema.attributes.forEach(function(a) { byName[a.name] = a; });
+      assert.strictEqual(byName.Entry.type, 'string');
+      assert.strictEqual(byName['Timer Period'].type, 'float');
+      assert.strictEqual(byName.isComplete.defaultValue, true);
+    });
+
+    it('describes a node whose type is already at its maximum', function() {
+      // The reason getChildTypeSchemas cannot answer this: it is
+      // scoped to a parent and filtered by cardinality, so by the
+      // time the one allowed Initial exists, its schema has been
+      // filtered out of its parent's list. Editing what is there is
+      // a different question from creating another.
+      var backend = LocalBackend(emptyModel());
+      var id;
+      backend.transact('add', function() {
+        id = backend.createChild('/p/m', 'Initial');
+      });
+      assert.ok(!backend.getValidChildTypes('/p/m').Initial,
+                'a second Initial should not be offered');
+      assert.ok(!backend.getChildTypeSchemas('/p/m').some(function(s) {
+        return s.name === 'Initial';
+      }), 'and so it is absent from the create-form schemas');
+
+      var schema = backend.getNodeSchema(id);
+      assert.ok(schema, 'but the node that exists still has a schema');
+      assert.strictEqual(schema.name, 'Initial');
+      assert.ok(schema.attributes.some(function(a) { return a.name === 'name'; }));
+    });
+
+    it('reports a connection as one, and has no schema for a stranger',
+       function() {
+         var backend = LocalBackend(emptyModel());
+         var id;
+         backend.transact('add', function() {
+           var a = backend.createChild('/p/m', 'State');
+           var b = backend.createChild('/p/m', 'State');
+           id = backend.createChild('/p/m', 'External Transition');
+           backend.setPointer(id, 'src', a);
+           backend.setPointer(id, 'dst', b);
+         });
+         assert.strictEqual(backend.getNodeSchema(id).isConnection, true);
+         assert.strictEqual(backend.getNodeSchema('/p/m/nope'), null);
+       });
+
     it('describes a type well enough to build a form for it', function() {
       var backend = LocalBackend(emptyModel());
       var schemas = backend.getChildTypeSchemas('/p/m');

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -34,6 +34,9 @@ function playgroundContext(name) {
       host: 'web/host',
       palette: 'web/palette',
     },
+    map: {
+      '*': { css: 'test/stubs/css' },
+    },
   });
 }
 
@@ -56,6 +59,9 @@ describe('playground editing', function () {
       'palette', 'host',
       'hfsm/metaRules', 'hfsm/viz/LocalBackend', 'hfsm/resolveModel',
       'hfsm/viz/describe', 'hfsm/checkModel',
+      // by its real path, not an alias: the module's own relative
+      // dependency (./CodeEditor) resolves against its id
+      'src/visualizers/widgets/HFSMViz/Inspector/Inspector',
     ]).then(function (loaded) {
       mods.palette = loaded[0];
       mods.PlaygroundHost = loaded[1];
@@ -64,6 +70,7 @@ describe('playground editing', function () {
       mods.resolveModel = loaded[4];
       mods.describe = loaded[5];
       mods.checkModel = loaded[6];
+      mods.Inspector = loaded[7];
     });
   });
 
@@ -222,6 +229,15 @@ describe('playground editing', function () {
            ['name', 'Event', 'Guard', 'Action', 'Enabled']);
        });
 
+    it('is a comparator that can say "equal"', function () {
+      // Array.sort's contract: a comparator that never returns 0 can
+      // order differently in a different engine
+      var same = { name: 'Entry', type: 'string' };
+      assert.deepStrictEqual(
+        mods.describe.fieldOrder([same, same]).map(function (a) { return a.name; }),
+        ['Entry', 'Entry']);
+    });
+
     it('orders every declared attribute exactly once', function () {
       Object.keys(mods.metaRules.types).forEach(function (type) {
         var declared = attrs(type);
@@ -315,6 +331,61 @@ describe('playground editing', function () {
                              ['name', 'Event']);
       assert.strictEqual(mods.checkModel.isValidString('has a space'), false);
       assert.strictEqual(mods.checkModel.isValidString('ARM'), true);
+    });
+  });
+
+  describe('what the inspector will store', function () {
+
+    // _normalize and _reject are pure: what they decide has to hold
+    // whatever the DOM around them is doing
+    function normalize(attr, value) {
+      return mods.Inspector.prototype._normalize({ name: attr }, value);
+    }
+    function reject(attr, value) {
+      return mods.Inspector.prototype._reject({ name: attr }, value);
+    }
+
+    it('validates exactly the value it will write', function () {
+      // The bug this pins: validating a TRIMMED copy and writing the
+      // original accepted " GO " as a valid `GO`, and
+      // checkModel.checkEvent -- which does not trim -- then rejected
+      // the model the inspector exists to keep valid.
+      [' GO ', 'GO\t', '\n GO'].forEach(function (typed) {
+        var stored = normalize('Event', typed);
+        assert.strictEqual(reject('Event', stored), null,
+                           JSON.stringify(typed) + ' should be accepted');
+        assert.strictEqual(mods.checkModel.isValidString(stored), true,
+                           'and what is stored must satisfy the checker');
+        assert.strictEqual(stored, 'GO');
+      });
+    });
+
+    it('trims a name too, and reports it as the checker would', function () {
+      var stored = normalize('name', '  State 1  ');
+      assert.strictEqual(stored, 'State 1');
+      assert.strictEqual(reject('name', stored), null);
+      assert.strictEqual(
+        mods.checkModel.isValidString(mods.checkModel.sanitizeString(stored)), true);
+    });
+
+    it('leaves code exactly as it was typed', function () {
+      // a trailing newline in an Entry block is the author's business
+      var code = '  printf("hi\\n");\n\n';
+      assert.strictEqual(normalize('Entry', code), code);
+      assert.strictEqual(normalize('Guard', ' x > 1 '), ' x > 1 ');
+      assert.strictEqual(reject('Entry', code), null, 'and is never rejected');
+    });
+
+    it('still refuses what the generator could not use', function () {
+      assert.ok(reject('Event', normalize('Event', 'has a space')));
+      assert.ok(reject('name', normalize('name', '   ')), 'a blank name');
+      assert.strictEqual(reject('Event', normalize('Event', '   ')), null,
+                         'but a blank Event just means no trigger');
+    });
+
+    it('normalizes only strings', function () {
+      assert.strictEqual(normalize('name', 42), 42);
+      assert.strictEqual(normalize('name', undefined), undefined);
     });
   });
 

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -213,6 +213,20 @@ describe('playground editing', function () {
       });
     });
 
+    it('gives everything long the same way out to a bigger editor',
+       function () {
+         // the pop-out is about ROOM, which prose needs as much as
+         // code does -- it just should not be numbered and
+         // highlighted as if it were C++
+         var expandable = mods.describe.CODE_ATTRIBUTES
+             .concat(mods.describe.PROSE_ATTRIBUTES);
+         expandable.forEach(function (name) {
+           var kind = mods.describe.fieldKind({ name: name, type: 'string' });
+           assert.ok(kind === 'code' || kind === 'prose',
+                     name + ' should be a long-form field');
+         });
+       });
+
     it('picks an input from the declared type', function () {
       assert.strictEqual(mods.describe.fieldKind({ name: 'isComplete', type: 'boolean' }),
                          'checkbox');

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -360,6 +360,45 @@ describe('playground editing', function () {
       });
     });
 
+    it('applies the name rule the CHECKER applies, per type', function () {
+      // Three different rules hide behind "name", and getting them
+      // wrong is invisible until a model is generated:
+      //
+      //  - an Event or Field name is emitted VERBATIM, so
+      //    'BUTTON-PRESS' must be refused rather than quietly become
+      //    BUTTON_PRESS;
+      //  - 'End_State' is a reserved generated name, so every other
+      //    type is refused it -- and the End State itself is not;
+      //  - everything else is sanitized first, so 'State 1' is fine.
+      function reject(type, name) {
+        return mods.Inspector.prototype._reject({ name: 'name' }, name, type);
+      }
+      assert.ok(reject('Event', 'BUTTON-PRESS'), 'an Event name is raw');
+      assert.strictEqual(reject('Event', 'BUTTON_PRESS'), null);
+      assert.ok(reject('Field', 'val-1'), 'a Field name is raw too');
+      assert.strictEqual(reject('Field', 'val_1'), null);
+
+      assert.strictEqual(reject('End State', 'End State'), null,
+                         'the conventional End State name is allowed');
+      assert.ok(reject('State', 'End State'),
+                'but nothing else may generate End_State');
+
+      assert.strictEqual(reject('State', 'State 1'), null, 'sanitized');
+      assert.ok(reject('State', '2fast'));
+      assert.ok(reject('State', 'class'), 'nor a C++ keyword');
+    });
+
+    it('says nothing about sanitizing where nothing is sanitized',
+       function () {
+         var note = function (type, name) {
+           return mods.Inspector.prototype._note({ name: 'name' }, name, type);
+         };
+         assert.strictEqual(note('State', 'State 1'), 'Generated as State_1');
+         assert.strictEqual(note('Event', 'GO'), null);
+         assert.strictEqual(note('Field', 'val'), null,
+                            'a Field name is emitted as typed');
+       });
+
     it('trims a name too, and reports it as the checker would', function () {
       var stored = normalize('name', '  State 1  ');
       assert.strictEqual(stored, 'State 1');

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -175,6 +175,97 @@ describe('playground editing', function () {
     });
   });
 
+  describe('how an attribute is shown', function () {
+
+    function attrs(type) {
+      var declared = mods.metaRules.types[type].attributes;
+      return Object.keys(declared).map(function (name) {
+        return { name: name, type: declared[name].type };
+      });
+    }
+
+    it('shows C++ as code, not as a one-line box', function () {
+      // the single worst thing about editing this model in a property
+      // grid: an Entry block in an <input>
+      mods.describe.CODE_ATTRIBUTES.forEach(function (name) {
+        assert.strictEqual(mods.describe.fieldKind({ name: name, type: 'string' }),
+                           'code', name + ' holds C++');
+      });
+    });
+
+    it('picks an input from the declared type', function () {
+      assert.strictEqual(mods.describe.fieldKind({ name: 'isComplete', type: 'boolean' }),
+                         'checkbox');
+      assert.strictEqual(mods.describe.fieldKind({ name: 'Timer Period', type: 'float' }),
+                         'number');
+      assert.strictEqual(mods.describe.fieldKind({ name: 'name', type: 'string' }),
+                         'text');
+      assert.strictEqual(mods.describe.fieldKind(null), 'text');
+    });
+
+    it('puts what the machine DOES before its bookkeeping', function () {
+      // alphabetical order buries Entry under Declarations and
+      // Definitions, which is how the property grid reads today
+      var order = mods.describe.fieldOrder(attrs('State'))
+          .map(function (a) { return a.name; });
+      assert.deepStrictEqual(order.slice(0, 4),
+                             ['name', 'Entry', 'Exit', 'Tick']);
+      assert.ok(order.indexOf('Entry') < order.indexOf('Declarations'));
+      assert.ok(order.indexOf('Entry') < order.indexOf('Includes'));
+    });
+
+    it('puts a transition in the order it reads: Event, Guard, Action',
+       function () {
+         var order = mods.describe.fieldOrder(attrs('External Transition'))
+             .map(function (a) { return a.name; });
+         assert.deepStrictEqual(order,
+           ['name', 'Event', 'Guard', 'Action', 'Enabled']);
+       });
+
+    it('orders every declared attribute exactly once', function () {
+      Object.keys(mods.metaRules.types).forEach(function (type) {
+        var declared = attrs(type);
+        var ordered = mods.describe.fieldOrder(declared);
+        assert.strictEqual(ordered.length, declared.length, type);
+        assert.deepStrictEqual(
+          ordered.map(function (a) { return a.name; }).sort(),
+          declared.map(function (a) { return a.name; }).sort(), type);
+      });
+      assert.deepStrictEqual(mods.describe.fieldOrder(undefined), []);
+    });
+
+    it('accepts a name the generator would accept, not a stricter one',
+       function () {
+         // Every existing model names states like "State 1".
+         // `checkName` sanitizes spaces and hyphens to underscores
+         // BEFORE checking, so that is a perfectly good name -- and a
+         // form that refused it would make the models we ship
+         // uneditable. `checkEvent` does not sanitize, so an event
+         // name really must already be an identifier.
+         var ok = function (n) {
+           return mods.checkModel.isValidString(mods.checkModel.sanitizeString(n));
+         };
+         assert.strictEqual(ok('State 1'), true, 'names may contain spaces');
+         assert.strictEqual(ok('Wait-For-Ack'), true, 'and hyphens');
+         assert.strictEqual(ok('2fast'), false, 'but not lead with a digit');
+         assert.strictEqual(ok('class'), false, 'nor be a C++ keyword');
+
+         assert.strictEqual(mods.checkModel.isValidString('INPUT EVENT'), false,
+                            'an Event is checked WITHOUT sanitizing');
+         assert.strictEqual(mods.checkModel.sanitizeString('State 1'), 'State_1',
+                            'and this is what the generated name becomes');
+       });
+
+    it('names the attributes that must be C++ identifiers', function () {
+      // an Event that is not one reaches the simulator, which says so
+      // with a modal; a name that is not one reaches the generator
+      assert.deepStrictEqual(mods.describe.IDENTIFIER_ATTRIBUTES,
+                             ['name', 'Event']);
+      assert.strictEqual(mods.checkModel.isValidString('has a space'), false);
+      assert.strictEqual(mods.checkModel.isValidString('ARM'), true);
+    });
+  });
+
   describe('the host', function () {
     it('satisfies the whole HostServices contract', function () {
       // the factory asserts this itself, so a missing method throws

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -200,6 +200,19 @@ describe('playground editing', function () {
       });
     });
 
+    it('shows prose as prose, and does not pretend it is C++', function () {
+      // `documentation` is markdown someone writes paragraphs in: a
+      // one-line input for it is the property-grid problem this panel
+      // exists to avoid, and highlighting it as C++ would be a lie
+      assert.strictEqual(
+        mods.describe.fieldKind({ name: 'documentation', type: 'string' }),
+        'prose');
+      mods.describe.PROSE_ATTRIBUTES.forEach(function (name) {
+        assert.ok(mods.describe.CODE_ATTRIBUTES.indexOf(name) === -1,
+                  name + ' is prose, not code');
+      });
+    });
+
     it('picks an input from the declared type', function () {
       assert.strictEqual(mods.describe.fieldKind({ name: 'isComplete', type: 'boolean' }),
                          'checkbox');
@@ -358,6 +371,23 @@ describe('playground editing', function () {
                            'and what is stored must satisfy the checker');
         assert.strictEqual(stored, 'GO');
       });
+    });
+
+    it('asks the checker about a transition Event too', function () {
+      // the same seam as names: restating the rule here is how the
+      // editor and the generator come to disagree
+      var reject = function (type, attr, value) {
+        return mods.Inspector.prototype._reject({ name: attr }, value, type);
+      };
+      assert.ok(reject('External Transition', 'Event', 'has a space'));
+      assert.strictEqual(reject('External Transition', 'Event', 'GO'), null);
+      assert.strictEqual(reject('External Transition', 'Event', ''), null,
+                         'no trigger is a real thing to be');
+      assert.strictEqual(
+        reject('External Transition', 'Event', 'has a space'),
+        mods.checkModel.identifierProblem('External Transition', 'Event',
+                                          'has a space'),
+        'and says exactly what the checker says');
     });
 
     it('applies the name rule the CHECKER applies, per type', function () {

--- a/test/playgroundEditing.spec.js
+++ b/test/playgroundEditing.spec.js
@@ -256,6 +256,58 @@ describe('playground editing', function () {
                             'and this is what the generated name becomes');
        });
 
+    it('does not offer to name a transition', function () {
+      // A transition's name is bookkeeping: the generator never emits
+      // it, and the diagram labels a transition `EVENT [guard]`, so
+      // nothing shows it. A field that looks like it matters and
+      // changes nothing is worse than no field.
+      ['External Transition', 'Local Transition', 'Internal Transition']
+        .forEach(function (type) {
+          var schema = {
+            name: type,
+            isConnection: mods.metaRules.isConnection(type),
+            attributes: attrs(type),
+          };
+          var shown = mods.describe.editableAttributes(schema)
+              .map(function (a) { return a.name; });
+          assert.ok(shown.indexOf('name') === -1,
+                    type + ' should not offer a name');
+          assert.deepStrictEqual(shown, ['Event', 'Guard', 'Action', 'Enabled'],
+                                 type + ': what is left is what it does');
+        });
+    });
+
+    it('keeps the name on everything the diagram labels by it', function () {
+      Object.keys(mods.metaRules.types).forEach(function (type) {
+        if (mods.metaRules.isAbstract(type)) return;
+        var schema = {
+          name: type,
+          isConnection: mods.metaRules.isConnection(type),
+          attributes: attrs(type),
+        };
+        if (mods.describe.labelledByEvent(schema)) return;   // transitions
+        var shown = mods.describe.editableAttributes(schema)
+            .map(function (a) { return a.name; });
+        assert.ok(shown.indexOf('name') > -1, type + ' should keep its name');
+      });
+    });
+
+    it('agrees with the label the diagram draws', function () {
+      // one rule, so the field list and the label cannot disagree
+      // about what a transition is
+      var edge = mods.describe.finish({ id: '/t', name: 'anything',
+                                        type: 'External Transition',
+                                        isConnection: true, Event: 'GO',
+                                        Guard: 'x > 1' });
+      assert.strictEqual(edge.LABEL, 'GO [x > 1]', 'labelled by its event');
+      var internal = mods.describe.finish({ id: '/i', name: 'anything',
+                                            type: 'Internal Transition',
+                                            Event: 'TICK' });
+      assert.strictEqual(internal.LABEL, 'TICK');
+      var state = mods.describe.finish({ id: '/s', name: 'Idle', type: 'State' });
+      assert.strictEqual(state.LABEL, 'Idle', 'a state is labelled by its name');
+    });
+
     it('names the attributes that must be C++ identifiers', function () {
       // an Event that is not one reaches the simulator, which says so
       // with a modal; a name that is not one reaches the generator

--- a/web/app.js
+++ b/web/app.js
@@ -36,6 +36,10 @@
       'css': 'vendor/css.min',
       'jquery': 'vendor/jquery.min',
       'bootstrap': 'vendor/bootstrap.min',
+      // the widget edits code attributes in CodeMirror; this is the
+      // same copy the page itself uses, under the id the widget asks
+      // for (WebGME maps it too -- see config/config.default.js)
+      'codemirror': 'vendor/codemirror',
       'cytoscape-edgehandles': 'vendor/bower/cytoscape-edgehandles/cytoscape-edgehandles',
       'cytoscape-context-menus': 'vendor/bower/cytoscape-context-menus/cytoscape-context-menus',
       'cytoscape-panzoom': 'vendor/bower/cytoscape-panzoom/cytoscape-panzoom',
@@ -62,12 +66,17 @@
     waitSeconds: 60,
   });
 
-  var CM_ID = 'vendor/codemirror/lib/codemirror';
+  // The SAME ids the widget's code editor asks for. An anonymous AMD
+  // module can only be claimed by one id: naming these files by path
+  // here and by `codemirror/...` there fetched them once and then left
+  // the widget's request pending forever, because the define() had
+  // already been consumed.
+  var CM_ID = 'codemirror/lib/codemirror';
   var CM_MODES = [
-    'vendor/codemirror/mode/javascript/javascript', // JSON
-    'vendor/codemirror/mode/clike/clike',           // C++
-    'vendor/codemirror/mode/xml/xml',               // SCXML
-    'vendor/codemirror/mode/shell/shell',           // Makefile (close enough)
+    'codemirror/mode/javascript/javascript', // JSON
+    'codemirror/mode/clike/clike',           // C++
+    'codemirror/mode/xml/xml',               // SCXML
+    'codemirror/mode/shell/shell',           // Makefile (close enough)
   ];
 
   var el = function (id) { return document.getElementById(id); };


### PR DESCRIPTION
You could not get far editing a machine from the diagram. A state dropped from the palette is called `State`, a transition has no event, and a second of either collides — so with no way to type a name, an Event, a Guard or an Entry block, the next thing you built was an invalid model.

Selecting anything now shows its attributes in the panel beside the diagram, editable in place.

## Deliberately not a property grid

WebGME answers this with its Property Editor, which belongs to the *application* rather than to the visualizer and so did not come across with the widget. It is also the least pleasant part of modelling with the tool, so this is not a copy of it:

- fields are ordered by what the machine **does** — name, Event, Guard, Action, Entry/Exit/Tick — with the rarely-touched declarations last, instead of alphabetically, which buries `Entry` under `Declarations` and `Definitions`;
- C++ is rendered as code in a textarea that grows, not in a one-line cell;
- a `name` or an `Event` the generator could not use is refused as it is typed, with the reason, instead of failing later — or, for an event name, reaching the simulator, which reports it with a modal;
- each committed field is one transaction, so it is one undo in a host that has undo.

## The contract gap

`getChildTypeSchemas` structurally cannot describe an existing node: it is scoped to a parent **and filtered by cardinality**, so by the time the one `Initial` a state is allowed exists, its schema has been filtered out of its parent's list. Editing what is there is a different question from creating another one.

`ModelBackend.getNodeSchema(id)` answers it, in both backends. Factoring it out also let `WebGMEBackend`'s two schema paths share one mapping.

## What counts as code, and what counts as a name

`describe` gained both answers, since the create dialog and the inspector have to agree. The nine code attributes are exactly the set the generator emits behind a `//::::<path>::::<attribute>::::` marker — which is also what will make them locatable in the generated file when the pop-out editor lands.

Validation is `checkModel`'s own rule, **per attribute**, and getting that wrong was caught by trying it on a real model: `checkName` sanitizes spaces and hyphens to underscores *before* checking, so `State 1` is a perfectly good name and every model we ship uses names like it — a stricter form would have made them uneditable. `checkEvent` does not sanitize, so an event name really must already be an identifier. A name that changes under sanitizing now says what it will be generated as, which nothing in the tool has ever told anyone.

## Verification

In the playground: selecting a state shows name, Entry, Exit, Tick, Timer Period, isComplete and the declarations in that order; renaming reaches the model, the graph label and the model text; `Timer Period` is stored as a number, not a string; a bad name or Event is refused and nothing is written; a transition offers Event, Guard, Action and Enabled and its label follows. Generating afterwards produces `class Armed` with its new Entry.

In WebGME, against `WebGMEBackend`: the panel renders beside the existing Property Editor, and a rename commits and reaches the diagram.

One behaviour worth knowing: the form updates values in place rather than rebuilding, and leaves a focused field alone. Rebuilding after each commit destroyed the input you had just tabbed into.

## Next

The pop-out code editor: CodeMirror (already vendored in both hosts) with the snippet shown inside the generated code it becomes, located by those markers, and navigation from snippet to snippet through the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy