### PR TITLE
Screenshots in the README and docs, hosted in the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Everything below happens on your own machine: edit the diagram,
 simulate it, read the generated C++, download the lot. Nothing is
 uploaded anywhere, and it works offline once loaded.
 
+[![The playground comparing an edited machine against the version it was loaded from](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-what-changed.jpg)](https://finger563.github.io/webgme-hfsm/)
+
+*Model on the left, diagram and simulator in the middle, and — here —
+a comparison against the version this machine was loaded from.*
+
 ---
 
 ## What it produces
@@ -214,6 +219,11 @@ right there instead of somewhere you have to go and look. A
 transition action compiled into six different places says so, and
 lets you step through all six.
 
+![A guard being edited inside the else-if it compiles into](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-code-context-guard.jpg)
+
+*A guard is emitted inside a line, so it is framed that way: `else if (`
+above what you are typing and `) {` below it.*
+
 **Simulate it.** Spawn events, tick, restart; watch the active branch
 light up and each entry / exit / action fire in order. Edit the
 machine's variables and event payloads mid-run to steer the guards.
@@ -222,10 +232,20 @@ machine's variables and event payloads mid-run to steer the guards.
 PlantUML and SCXML — readable in the browser, downloadable as a set.
 
 **Compare two versions.** *Compare…* puts another model beside this
-one and marks up what changed: added, removed, changed, with a list
-naming each difference. Compare against the version you loaded to
-answer *what have I changed?* See
-[docs/PLAYGROUND.md](docs/PLAYGROUND.md#comparing-two-machines).
+one and marks up what changed — added in green, removed in red and
+dashed, changed in amber and dotted — with a list naming each
+difference. Clicking an entry takes the diagram to it. Compare
+against the version you loaded to answer *what have I changed?*
+
+![The change list naming each difference](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-change-list.png)
+
+Comparing two genuinely different machines shows the other half:
+whatever the older one had is put back where it used to be, so you
+can see what went.
+
+![Two different machines compared](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-two-machines.jpg)
+
+More in [docs/PLAYGROUND.md](docs/PLAYGROUND.md#comparing-two-machines).
 
 **It does not lose your work.** The model is kept per browser tab, so
 a refresh — or a crash — brings back what you were editing, along
@@ -387,7 +407,6 @@ code which traces when transitions are fired, which guards are true,
 which actions are executed, and which events are in the State
 Machine's event queue.
 
-[![Asciinema recording of interactive test bench](https://asciinema.org/a/kWbxIsIDlQ0ysAlp0ss9X8zJw.png)](https://asciinema.org/a/kWbxIsIDlQ0ysAlp0ss9X8zJw?t=9)
 
 <details><summary>Example Test Bench Output for the Complex Example State Machine</summary><p>
 

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -135,6 +135,8 @@ That question — *what can I write here?* — previously had no answer
 inside the tool. People generated the code and read it, which meant
 leaving the editor.
 
+![A guard framed by the else-if it compiles into](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-code-context-guard.jpg)
+
 It costs no new machinery. The generator already marks every snippet
 it emits:
 
@@ -189,8 +191,18 @@ the editor opening.
 
 **Compare…** on the Diagram tab puts a second model beside the one in
 the editor and shows what changed: added in green, removed in red and
-dashed, changed in amber, with a list beside the diagram saying what
-each change actually was.
+dashed, changed in amber and dotted, with a list beside the diagram
+saying what each change actually was.
+
+![Comparing against the version the model was loaded from](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-what-changed.jpg)
+
+The colours say **where** something changed; the list says **what**.
+Neither is much use alone — a state outlined in amber does not tell
+you its guard now reads `false`, and a list of paths does not tell you
+where in the machine they are. Clicking an entry moves the diagram to
+it, which is the join between the two.
+
+![The change list](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-change-list.png)
 
 You can compare against **the version you loaded** — the most useful
 one, because it answers *what have I changed?* — against any built-in
@@ -241,6 +253,12 @@ The comparison is **read-only**: what is on screen belongs to neither
 model, so an edit could not be saved back to either without silently
 picking one. The palette goes away and Save layout is hidden while it
 is on.
+
+Comparing two machines that share no history shows how much of this
+is doing real work: everything the older one had is re-homed and
+drawn dashed, so what went is as visible as what arrived.
+
+![Two different machines compared](https://raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/playground-diff-two-machines.jpg)
 
 A removed transition whose endpoint is in neither model cannot be
 drawn at all. It is dropped — and said, in the panel, rather than


### PR DESCRIPTION
Follow-up to #232: the README had no picture of the playground, and the ones from #231 were parked on an orphan branch of this repo.

## Where the images live now

The wiki, alongside the gifs the README has always used
(`raw.githubusercontent.com/wiki/finger563/webgme-hfsm/images/...`) —
[pushed as `f4051a8`](https://github.com/finger563/webgme-hfsm/wiki). That means the `screenshots/visual-diff` orphan branch can go, and **PR #231's body has already been repointed** at the wiki copies, so deleting that branch won't break the merged PR's history.

## What each one is doing

- **The comparison view**, immediately under the *try it in your browser* link and linking to it. A statechart tool whose README shows no statechart is asking for a lot of faith.
- **A guard framed by the `else if (` it compiles into** — the part of the code-context editor that nobody believes until they see it.
- **The change list**, and **two unrelated machines compared**, in both the README and `docs/PLAYGROUND.md`.

## One removal worth flagging

The asciinema embed is gone. That recording is **404 for both the thumbnail and the page**, so it rendered as a broken image and linked nowhere — not what you want in the first screen before a release. The same test-bench trace is already inline in the `<details>` block directly below it, so nothing was lost. Easy to restore with a fresh recording if you'd like one back.

## Checked

- Every image URL in `README.md` and `docs/` fetched with curl: all 200 (that dead asciinema link was the only failure, and it predates this branch)
- Code fences balanced, no malformed image markdown, no broken anchors in either file
- 238 tests still pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy