### PR TITLE
Frame a snippet from the model as it is now

### DIFF
--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -176,16 +176,47 @@ If the value is not where the marker says it should be, the file was
 generated from a different model, and there is no frame at all rather
 than one drawn in the wrong place.
 
-The frame comes from the host, through the optional `generated()`
+### It is about the model as it is now
+
+Opening a snippet **asks the page to generate**, there and then, for
+the model currently in the editor. It does not use whatever *Generate*
+last produced.
+
+That distinction was originally the other way round, and it was wrong
+in a way that took using it to notice. Edit a guard and the frame
+still showed the old surroundings. Add a state and open its Entry and
+there was **no frame at all** — that state was in no generated file
+yet, so there was nothing to find. Nothing said so; the frame just
+quietly wasn't there, and knowing to press *Generate* first was
+something you had to be told. That is training, not a tool.
+
+It is affordable because generating is not expensive: a few
+milliseconds for the largest example here, cached against the model
+text so opening ten snippets in a row renders once. Pressing
+*Generate* is still how you get files to read and download — this is a
+private render nobody sees.
+
+### It always says something
+
+Three different things can mean "no frame", and they used to look
+identical:
+
+- **This host has no generated code.** WebGME, where the plugin runs
+  on the server and the visualizer has never seen its output. Not a
+  fault, so nothing is said.
+- **The model will not generate right now.** Normal half-way through
+  an edit — and the commonest cause is a state you have just created,
+  because `Timer Period` defaults to `0` and a leaf state needs more
+  than that. The editor shows the checker's own message, so you find
+  out while editing rather than when you next press *Generate*.
+- **This snippet is not emitted anywhere.** A disabled transition, or
+  a state nothing reaches. Said plainly.
+
+The frame comes from the host through the optional `generated()`
 service, which returns the files **and the model they came from** —
 both together, because files paired with the wrong model produce a
-frame that is fiction. Where generated code comes from is genuinely
-host-specific: the playground generates in the page and has both to
-hand, while in WebGME the plugin runs on the server and the visualizer
-has never seen its output. A host that cannot
-answer loses the frame and nothing else — including a host whose
-generation just failed, which is caught rather than allowed to stop
-the editor opening.
+frame that is fiction. It is a function rather than a value precisely
+so the answer can be about the model at the moment it is asked for.
 
 ## Comparing two machines
 

--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -176,6 +176,17 @@ If the value is not where the marker says it should be, the file was
 generated from a different model, and there is no frame at all rather
 than one drawn in the wrong place.
 
+The frame is **syntax highlighted too**, on a muted palette. It is
+generated C++ — a signature, then a column of
+`[[maybe_unused]] auto &x = _root->x;` aliases — and that is a lot of
+punctuation to read as one flat grey block, when the aliases are the
+part people came to read. What marks the frame as not-editable is the
+shaded ground, the dashed separators and the white editor between
+them; it never needed to be unreadable as well. CodeMirror's
+`runMode` does the highlighting: it tokenizes a string into a plain
+element, with no editor, no cursor and no second copy of the
+document.
+
 ### It is about the model as it is now
 
 Opening a snippet **asks the page to generate**, there and then, for

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -70,6 +70,7 @@ say "vendor (requirejs, text, handlebars, underscore)"
 # library twice and the modes would register on the wrong copy.
 CM_SRC="$(dirname "$(find_first "$REPO_ROOT/node_modules/codemirror/lib/codemirror.js")")/.."
 mkdir -p "$OUT/vendor/codemirror/lib" \
+         "$OUT/vendor/codemirror/addon/runmode" \
          "$OUT/vendor/codemirror/mode/javascript" \
          "$OUT/vendor/codemirror/mode/clike" \
          "$OUT/vendor/codemirror/mode/xml" \
@@ -80,7 +81,10 @@ cp "$CM_SRC/mode/javascript/javascript.js" "$OUT/vendor/codemirror/mode/javascri
 cp "$CM_SRC/mode/clike/clike.js"           "$OUT/vendor/codemirror/mode/clike/"
 cp "$CM_SRC/mode/xml/xml.js"               "$OUT/vendor/codemirror/mode/xml/"
 cp "$CM_SRC/mode/shell/shell.js"           "$OUT/vendor/codemirror/mode/shell/"
-say "codemirror (json, c++, xml, shell modes)"
+# runMode highlights a string into a plain element, with no editor
+# attached -- what the code editor's read-only context frames use
+cp "$CM_SRC/addon/runmode/runmode.js" "$OUT/vendor/codemirror/addon/runmode/"
+say "codemirror (json, c++, xml, shell modes; runmode)"
 
 # 3b. the visualizer: the SAME widget and simulator WebGME runs, not a
 #     second implementation. Phase A/B put the model behind

--- a/scripts/verify-web-build.js
+++ b/scripts/verify-web-build.js
@@ -47,6 +47,7 @@ function must(file) {
  'vendor/codemirror/mode/clike/clike.js',
  'vendor/codemirror/mode/xml/xml.js',
  'vendor/codemirror/mode/shell/shell.js',
+ 'vendor/codemirror/addon/runmode/runmode.js',
  'src/common/resolveModel.js', 'src/common/processor.js',
  'src/common/checkModel.js', 'src/common/declParser.js',
  'src/common/exporters.js',

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -147,7 +147,7 @@ define(['require'], function (require) {
      * The same code, full size, in a modal.
      *
      * @param opts  { title, subtitle, value, readOnly, prose, sites,
-     *                onSave }
+     *                note, onSave }
      *   `prose` for markdown rather than C++: wrapped, unnumbered and
      *   unhighlighted, because paragraphs want the width and
      *   colouring prose as code would be a lie. The room is the point
@@ -161,6 +161,10 @@ define(['require'], function (require) {
      *   site is not a problem to hide: a transition's action really
      *   is compiled into every place that transition can be taken,
      *   and stepping through them is the only way to see that.
+     *
+     *   `note` is why there is no frame, when there is none and the
+     *   reason is worth saying. An editor that simply shows less than
+     *   usual, with nothing to explain it, reads as broken.
      * @return a function that closes it
      */
     open: function (opts) {
@@ -305,6 +309,10 @@ define(['require'], function (require) {
         body.append(before, $('<div class="code-modal-edit"></div>').append(area),
                     after);
       } else {
+        if (opts.note) {
+          head.append($('<span class="code-modal-note"></span>')
+                      .text(opts.note).attr('title', opts.note));
+        }
         body.append(area);
       }
       box.append(head, body, buttons.append(hint, cancel, save));

--- a/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/CodeEditor.js
@@ -44,7 +44,12 @@ define(['require'], function (require) {
   function editor() {
     if (!pending) {
       pending = new Promise(function (resolve, reject) {
-        require(['codemirror/lib/codemirror', 'codemirror/mode/clike/clike'],
+        // runmode comes along for the read-only context frames: it
+        // highlights a string into a plain element without building
+        // an editor around it
+        require(['codemirror/lib/codemirror',
+                 'codemirror/mode/clike/clike',
+                 'codemirror/addon/runmode/runmode'],
                 function (CodeMirror) { resolve(CodeMirror); }, reject);
       });
     }
@@ -216,11 +221,40 @@ define(['require'], function (require) {
           .attr('title', 'The next place this is generated into')
           .attr('aria-label', 'The next place this is generated into');
 
+      /**
+       * Put framing code into an element, highlighted if it can be.
+       *
+       * The frame is generated C++ -- function signatures and a
+       * column of `[[maybe_unused]] auto &x = _root->x;` aliases --
+       * which is a lot of punctuation to read as one flat grey block.
+       * Highlighting it makes the aliases scannable; the muted
+       * palette in the stylesheet is what keeps it reading as context
+       * rather than as the thing being edited.
+       *
+       * runMode rather than a CodeMirror instance: this is text to
+       * read, not an editor. No cursor, no gutter, no second copy of
+       * the document. Falls back to plain text before CodeMirror has
+       * loaded, and if it never does.
+       */
+      function fill(el, code) {
+        el.empty();
+        if (CodeMirror && CodeMirror.runMode) {
+          try {
+            CodeMirror.runMode(code, MODE, el[0]);
+            return;
+          } catch (e) {
+            // highlighting is a nicety; the code still has to appear
+            console.error('Could not highlight the context frame: ', e);
+          }
+        }
+        el.text(code);
+      }
+
       function showSite() {
         var site = sites[siteIndex];
         if (!site) return;
-        before.text(site.before);
-        after.text(site.after);
+        fill(before, site.before);
+        fill(after, site.after);
         // The lines NEAREST the snippet are the ones worth seeing: the
         // aliases just above it, the brace just below. So a frame too
         // tall to fit shows its bottom, and the one below shows its

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -244,6 +244,35 @@ textarea.inspector-prose {
        reasonable thing to want; just not editable */
     border: 0;
 }
+/* Highlighted, but quieter than the editor.
+   
+   The frame is generated C++: a signature, then a column of
+   `[[maybe_unused]] auto &x = _root->x;` aliases. That is a lot of
+   punctuation to read as one flat grey block, and the aliases are the
+   part people actually came to read -- they say what is in scope.
+   
+   So the tokens are coloured, on a muted palette against the shaded
+   ground. What marks the frame as not-editable is the background, the
+   dashed separators and the white editor between them; it never
+   needed to be unreadable as well. Anything runMode does not tokenize
+   keeps the grey set on .code-context. */
+.code-context .cm-comment  { color: #6a737d; font-style: italic; }
+.code-context .cm-keyword   { color: #8250df; }
+.code-context .cm-builtin,
+.code-context .cm-atom      { color: #0550ae; }
+.code-context .cm-number    { color: #0550ae; }
+.code-context .cm-string,
+.code-context .cm-string-2  { color: #0a3069; }
+.code-context .cm-def       { color: #24292f; }
+.code-context .cm-variable,
+.code-context .cm-variable-2 { color: #57606a; }
+.code-context .cm-variable-3,
+.code-context .cm-type      { color: #953800; }
+.code-context .cm-meta      { color: #6e7781; }
+.code-context .cm-operator  { color: #57606a; }
+.code-context .cm-bracket   { color: #8c959f; }
+.code-context .cm-error     { color: #cf222e; }
+
 /* they are focusable so they can be scrolled from the keyboard;
    a focus ring that only shows for keyboard users keeps that from
    flashing up on every click */

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.css
@@ -287,6 +287,18 @@ textarea.inspector-prose {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+/* why there is no frame -- muted, since it is an explanation and
+   not a warning */
+.code-modal-note {
+    margin-left: auto;
+    color: #57606a;
+    font-size: 11px;
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .code-modal-step {
     font: inherit;
     font-size: 13px;

--- a/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
+++ b/src/visualizers/widgets/HFSMViz/Inspector/Inspector.js
@@ -362,17 +362,36 @@ define(['hfsm/viz/describe',
    * Where this snippet ends up in the generated code, if the host can
    * say.
    *
-   * Measured against the model the code was GENERATED from, which the
-   * host hands over with the files -- not against what is in the
-   * editor. Using the editor's text slid the frame the moment anyone
-   * typed.
+   * Measured against the model the generated code came from -- which
+   * the host supplies together with the files, because a frame
+   * measured against a different model is fiction.
+   *
+   * ALWAYS SAYS SOMETHING. A missing frame used to be silence, and
+   * silence is indistinguishable from a bug: you could not tell "this
+   * code is not emitted anywhere" from "the model will not generate"
+   * from "this host has no generated code to offer". Each of those
+   * now comes back with its reason, for the editor to show.
+   *
+   * @return { sites, note }
    */
   Inspector.prototype._sites = function (id, attr) {
     var self = this;
-    if (describe.fieldKind(attr) !== 'code') return [];   // prose is not compiled
+    // prose is markdown; it is never compiled into anything, so there
+    // is no function to show it inside and nothing to explain
+    if (describe.fieldKind(attr) !== 'code') return { sites: [] };
+
     var generated = HostServices.ask(self._host, 'generated', [], null);
-    if (!generated) return [];
-    return codeContext.sites(generated, id, attr.name);
+    // the host offers none at all -- WebGME, where the plugin runs on
+    // the server. Not a fault, and not worth a note on every open.
+    if (!generated) return { sites: [] };
+    if (generated.problem) return { sites: [], note: generated.problem };
+
+    var sites = codeContext.sites(generated, id, attr.name);
+    if (!sites.length) {
+      return { sites: [], note: 'Not emitted in the generated code — a ' +
+               'disabled transition, or a state nothing reaches.' };
+    }
+    return { sites: sites };
   };
 
   Inspector.prototype._expand = function (id, attr) {
@@ -381,11 +400,13 @@ define(['hfsm/viz/describe',
     if (!field) return;
     var node = self._backend.getNode(id);
     var value = readValue(field);
+    var context = self._sites(id, attr);
     CodeEditor.open({
       title: attr.name,
       subtitle: (node && node.name ? node.name + '  ' : '') + id,
       value: value,
-      sites: self._sites(id, attr),
+      sites: context.sites,
+      note: context.note,
       readOnly: self._backend.isReadOnly(),
       prose: field.kind === 'prose',
       onSave: function (next) {

--- a/test/codeContext.spec.js
+++ b/test/codeContext.spec.js
@@ -286,9 +286,23 @@ describe('asking the host for a frame', function () {
   var ENTRY = { name: 'Entry', type: 'string' };
 
   it('asks for code', function () {
-    var sites = withHost({ generated: function () { return generated; } })
+    var context = withHost({ generated: function () { return generated; } })
         ._sites('/c/T', ENTRY);
-    assert.strictEqual(sites.length, 1);
+    assert.strictEqual(context.sites.length, 1);
+    assert.ok(!context.note, 'nothing to explain when there is a frame');
+  });
+
+  it('asks the host at the moment the snippet is opened', function () {
+    // The whole point: the answer must be about the model as it is
+    // NOW, not as it was when Generate was last pressed. So the host
+    // is CALLED, not read.
+    var calls = 0;
+    var inspector = withHost({
+      generated: function () { calls++; return generated; },
+    });
+    inspector._sites('/c/T', ENTRY);
+    inspector._sites('/c/T', ENTRY);
+    assert.strictEqual(calls, 2, 'asked every time, not cached in here');
   });
 
   it('does not ask for prose', function () {
@@ -297,22 +311,24 @@ describe('asking the host for a frame', function () {
     var host = { generated: function () { return generated; } };
     assert.deepStrictEqual(
       withHost(host)._sites('/c/T', { name: 'documentation', type: 'string' }),
-      []);
+      { sites: [] }, 'and nothing to explain -- prose is simply not code');
   });
 
   it('degrades to no frame rather than failing', function () {
     // this is the WebGME case: the plugin runs on the server, so the
     // visualizer has never seen generated code
-    assert.deepStrictEqual(withHost(null)._sites('/c/T', ENTRY), []);
-    assert.deepStrictEqual(withHost({})._sites('/c/T', ENTRY), []);
+    // A host with nothing to offer -- WebGME, where the plugin runs
+    // on the server -- is not a fault, so it gets no note.
+    assert.deepStrictEqual(withHost(null)._sites('/c/T', ENTRY), { sites: [] });
+    assert.deepStrictEqual(withHost({})._sites('/c/T', ENTRY), { sites: [] });
     assert.deepStrictEqual(
       withHost({ generated: function () { return null; } })
-        ._sites('/c/T', ENTRY), []);
+        ._sites('/c/T', ENTRY), { sites: [] });
     // files without the model they came from is not enough to measure
     // anything, so it is not enough to draw a frame
     assert.deepStrictEqual(
       withHost({ generated: function () { return { files: files }; } })
-        ._sites('/c/T', ENTRY), []);
+        ._sites('/c/T', ENTRY).sites, []);
   });
 
   it('survives a host that throws', function () {
@@ -320,7 +336,7 @@ describe('asking the host for a frame', function () {
     // than an editor with no frame
     assert.deepStrictEqual(
       withHost({ generated: function () { throw new Error('boom'); } })
-        ._sites('/c/T', ENTRY), []);
+        ._sites('/c/T', ENTRY), { sites: [] });
   });
 
   it('labels the step buttons, not just their tooltips', function () {
@@ -347,11 +363,145 @@ describe('asking the host for a frame', function () {
     });
   });
 
+  it('says why there is no frame, rather than showing less and saying nothing',
+     function () {
+       // A model that will not generate is normal half-way through an
+       // edit. The editor should say that is what happened, because
+       // an editor that quietly shows less than usual reads as broken.
+       var context = withHost({
+         generated: function () { return { problem: 'it does not compile' }; },
+       })._sites('/c/T', ENTRY);
+       assert.deepStrictEqual(context.sites, []);
+       assert.strictEqual(context.note, 'it does not compile');
+     });
+
+  it('says when a snippet is simply not generated anywhere', function () {
+    // a state nothing reaches, or a disabled transition: real, saved,
+    // and in none of the output
+    var context = withHost({ generated: function () { return generated; } })
+        ._sites('/nowhere', ENTRY);
+    assert.deepStrictEqual(context.sites, []);
+    assert.ok(/not emitted/i.test(context.note), context.note);
+  });
+
   it('offers generated as optional, not required', function () {
     assert.ok(HostServices.OPTIONAL.indexOf('generated') > -1);
     assert.ok(HostServices.REQUIRED.indexOf('generated') === -1,
               'a host without it is not a broken host');
     // and the do-nothing host answers it
     assert.strictEqual(HostServices.none().generated(), null);
+  });
+});
+
+/**
+ * The frame has to be about the model as it is NOW.
+ *
+ * This is the bug the on-demand generation fixes, reproduced at the
+ * level it actually happens: edit the model, then ask where a snippet
+ * lands. Against the LAST generation the answer is wrong or missing;
+ * against a fresh one it is right. Nothing here touches a browser --
+ * what is being checked is that regenerating is enough.
+ */
+describe('framing a snippet after the model has been edited', function () {
+  this.timeout(20000);
+
+  var codeContext, generate, base;
+
+  before(function () {
+    var amdLoader = require('../bin/amd-loader');
+    return amdLoader.load([
+      'src/common/viz/codeContext',
+      'src/common/resolveModel',
+      'src/common/processor',
+      'src/plugins/SoftwareGenerator/templates/MetaTemplates',
+    ]).then(function (loaded) {
+      codeContext = loaded[0];
+      var resolveModel = loaded[1], processor = loaded[2], MetaTemplates = loaded[3];
+      // what the page's generationForContext does, minus the DOM
+      generate = function (text) {
+        var model = JSON.parse(text);
+        resolveModel.resolve(model);
+        processor.processModel(model);
+        return { files: MetaTemplates.renderHFSM(model, 'state_machine'),
+                 model: model };
+      };
+      base = fs.readFileSync(
+        path.join(repoRoot, 'examples/Complex.json'), 'utf8');
+    });
+  });
+
+  it('frames a state that did not exist at the last generation', function () {
+    // THE reported case: add a state, open its Entry, get nothing --
+    // because that state is in no generated file yet.
+    var stale = generate(base);
+    var edited = JSON.parse(base);
+    edited.objects['/c/NEW'] = { name: 'Recovering', type: 'State',
+                                 position: { x: 10, y: 10 },
+                                 'Timer Period': 1,
+                                 Entry: 'retries = 0;' };
+    var text = JSON.stringify(edited);
+
+    assert.deepStrictEqual(codeContext.sites(stale, '/c/NEW', 'Entry'), [],
+                           'against the last generation: no frame at all');
+
+    var fresh = generate(text);
+    var sites = codeContext.sites(fresh, '/c/NEW', 'Entry');
+    assert.strictEqual(sites.length, 1, 'against a fresh one: framed');
+    assert.ok(/void Root::Recovering::entry/.test(sites[0].before),
+              'and it is the right function: ' + sites[0].before.split('\n')[0]);
+  });
+
+  it('a state created with the metamodel default cannot be generated at all',
+     function () {
+       // Worth pinning, because it is the OTHER reason a frame goes
+       // missing after an edit, and it is not this feature's fault:
+       // `Timer Period` defaults to 0 in the metamodel, and checkModel
+       // requires a leaf state to have more than 0. So a state
+       // straight from the palette makes the whole model fail to
+       // generate until someone sets one.
+       //
+       // The editor no longer swallows that -- it shows the reason --
+       // but the trap is upstream of here.
+       var edited = JSON.parse(base);
+       edited.objects['/c/NEW'] = { name: 'Recovering', type: 'State',
+                                    position: { x: 10, y: 10 } };
+       assert.throws(function () { generate(JSON.stringify(edited)); },
+                     /Timer Period/,
+                     'a palette-fresh state should still be rejected here');
+     });
+
+  it('frames an edited guard by what it says now, not what it said', function () {
+    var guarded = '/c/Y/t';
+    var edited = JSON.parse(base);
+    var was = edited.objects[guarded].Guard;
+    assert.ok(was, 'fixture should have a guard');
+    edited.objects[guarded].Guard = 'someNumber > 99';
+    var text = JSON.stringify(edited);
+
+    var stale = generate(base);
+    var staleSites = codeContext.sites(stale, guarded, 'Guard');
+    if (staleSites.length) {
+      assert.ok(staleSites[0].before.indexOf(was) === -1 ||
+                staleSites[0].after.indexOf(was) === -1,
+                'sanity: the stale frame is built around the old value');
+    }
+
+    var fresh = generate(text);
+    var sites = codeContext.sites(fresh, guarded, 'Guard');
+    assert.ok(sites.length, 'the edited guard is framed');
+    sites.forEach(function (site) {
+      assert.ok(site.before.indexOf('someNumber > 99') === -1,
+                'the guard itself is not inside its own frame');
+    });
+  });
+
+  it('costs little enough to do whenever a snippet is opened', function () {
+    // The frame used to be tied to a button press on the theory that
+    // generating was expensive. It is not: this is what makes doing
+    // it on demand the right answer rather than a trade-off.
+    var t0 = Date.now();
+    for (var i = 0; i < 5; i++) generate(base);
+    var each = (Date.now() - t0) / 5;
+    assert.ok(each < 250, 'generating Complex took ' + each.toFixed(0) + 'ms');
   });
 });

--- a/web/app.js
+++ b/web/app.js
@@ -456,12 +456,8 @@
       return;
     }
 
-    // Same precedence as the CLI (bin/hfsm-gen.js): an explicit
-    // value wins, then the model's own `namespace`, then the default.
-    // Leaving the box empty therefore means "use the model's".
-    var namespace = (el('namespaceInput').value || '').trim() ||
-        (typeof model.namespace === 'string' && model.namespace.trim()) ||
-        'state_machine';
+    // Leaving the box empty means "use the model's" -- see namespaceFor
+    var namespace = namespaceFor(model);
     if (!/^[A-Za-z_]\w*(::[A-Za-z_]\w*)*$/.test(namespace)) {
       showDiagnostics(['Invalid C++ namespace "' + namespace +
                        '" (expected identifier or identifier::identifier...).'], 'error');
@@ -518,19 +514,11 @@
     // non-fatal model warnings surface the same way the CLI prints them
     showDiagnostics(model.warnings || [], 'warn');
 
-    // The code editor shows a snippet inside the function it is
-    // compiled into, and this is where it reads that from. The MODEL
-    // goes with the files: it is the only thing that says how much
-    // of the file a snippet occupies, and a frame measured against a
-    // different model is fiction. Handed over on every successful
-    // generation, and only then -- half a generation would frame the
-    // code with the wrong surroundings.
-    var generated = { files: artifacts, model: model };
-    if (vizModule && vizModule.setGenerated) {
-      vizModule.setGenerated(generated);
-    } else {
-      pendingGenerated = generated;
-    }
+    // The editor's context frame reads from a render of the CURRENT
+    // model, not from this one -- but this one is current as of right
+    // now, so hand it over rather than doing the same work again the
+    // first time somebody opens a snippet.
+    contextCache = { text: raw, result: { files: artifacts, model: model } };
 
     var count = Object.keys(artifacts).length;
     renderFileList();
@@ -551,6 +539,64 @@
     // with it, and doing that on every keystroke would throw away
     // work nobody asked to discard.
     refreshDiagram({ keepStatus: true });
+  }
+
+  /* ------------- generated code, for the editor's frame ------------ */
+
+  /**
+   * The namespace a generation should use.
+   *
+   * Same precedence as the CLI (bin/hfsm-gen.js): an explicit value
+   * wins, then the model's own `namespace`, then the default.
+   */
+  function namespaceFor(model) {
+    return (el('namespaceInput').value || '').trim() ||
+      (typeof model.namespace === 'string' && model.namespace.trim()) ||
+      'state_machine';
+  }
+
+  /**
+   * Generated code for the code editor to frame a snippet with.
+   *
+   * WHY THIS IS A FUNCTION AND NOT A VALUE
+   * --------------------------------------
+   * The frame has to match the model as it is NOW. It used to be
+   * whatever Generate last produced, which meant the surroundings
+   * were stale the moment you changed anything -- and a state you had
+   * just added had no frame at all, because it was in no generated
+   * file yet. Nothing said so; the frame simply went missing, and
+   * knowing to press Generate first was something you had to be told.
+   *
+   * So the page renders on demand instead. It costs a few
+   * milliseconds, it is cached against the model text so opening ten
+   * snippets in a row renders once, and it is quiet: no file list, no
+   * status, no diagnostics. Pressing Generate is still how you get
+   * files to read and download -- this is not that.
+   *
+   * @return { files, model } | { problem } | null
+   */
+  function generationForContext() {
+    if (!mods) return null;                 // generator still loading
+    var raw = getModelText().trim();
+    if (!raw) return { problem: 'There is no model yet.' };
+    if (contextCache.text === raw) return contextCache.result;
+
+    var result;
+    try {
+      var model = JSON.parse(raw);
+      mods.resolveModel.resolve(model);
+      mods.processor.processModel(model);
+      result = { files: mods.MetaTemplates.renderHFSM(model, namespaceFor(model)),
+                 model: model };
+    } catch (err) {
+      // Half-finished edits are normal while modelling, so this is
+      // not an error to shout about -- but the editor should say why
+      // there is no frame rather than showing an empty one.
+      result = { problem: 'The model does not generate right now: ' +
+                 (typeof err === 'string' ? err : (err && err.message) || String(err)) };
+    }
+    contextCache = { text: raw, result: result };
+    return result;
   }
 
   /* ------------------ comparing two machines ---------------------- */
@@ -944,8 +990,11 @@
   // generated code
   var vizModule = null;
   var vizShown = false;
-  // generated files produced before the visualizer existed
-  var pendingGenerated = null;
+  // The last generation done FOR THE CODE EDITOR's context frame,
+  // keyed by the model text it came from. Not the same thing as
+  // pressing Generate: that publishes files for the user to read and
+  // download, this is a private render nobody sees.
+  var contextCache = { text: null, result: null };
   // the comparison currently on screen, or null
   var comparison = null;
   // Which draw is the current one.
@@ -1069,13 +1118,11 @@
     requirejs(['viz'], function (viz) {
       vizModule = viz;
       if (token !== drawToken) return;   // something else is drawing now
-      // generate() can run before the visualizer has ever loaded --
-      // it does, on a restored draft -- so the files it produced are
-      // held until there is something to give them to
-      if (pendingGenerated) {
-        viz.setGenerated(pendingGenerated);
-        pendingGenerated = null;
-      }
+      // The visualizer asks for this when someone opens a snippet, so
+      // it is a function rather than a value: whatever the model says
+      // AT THAT MOMENT, not whatever it said when Generate was last
+      // pressed.
+      viz.setGenerated(generationForContext);
       viz.onModelEdited(diagramEdited);
       viz.onSplitChanged(function () {
         rememberLayout({ diagramSplits: viz.splitSizes() });

--- a/web/host.js
+++ b/web/host.js
@@ -40,35 +40,34 @@ define(['jquery', 'hfsm/viz/HostServices'], function ($, HostServices) {
     // backend that are gone.
     this._closeMenu = null;
     this._closeDialog = null;
-    // what the page last generated -- files AND the model they came
-    // from -- for the code editor's frame
+    // asked for generated code when someone opens a snippet; see
+    // setGenerated
     this._generated = null;
   }
 
   /* --------------------- generated code ----------------------- */
 
   /**
-   * What the page produced the last time Generate ran: the files,
-   * and the model they were generated from.
+   * Generated code for the code editor to frame a snippet with.
    *
-   * Deliberately whatever was generated LAST, not what the model
-   * currently says: the editor uses this to show a snippet in
-   * context, and the surroundings of a function do not change every
-   * time someone types. A model edited since is at worst framed by
-   * the previous version of the same function; a frame that vanished
-   * on every keystroke would be worse.
+   * Asked for at the moment a snippet is opened, so the answer can be
+   * about the model as it is THEN. The page decides whether that
+   * means reusing the last render or doing another one; all this does
+   * is ask.
    *
-   * The model travels WITH the files because that is the only thing
-   * that says how much of the file the snippet occupies -- see
+   * The model travels with the files because it is the only thing
+   * that says how much of the file a snippet occupies -- see
    * codeContext.
+   *
+   * @return { files, model } | { problem } | null
    */
   PlaygroundHost.prototype.generated = function () {
-    return this._generated;
+    return this._generated ? this._generated() : null;
   };
 
-  PlaygroundHost.prototype.setGenerated = function (generated) {
-    this._generated = (generated && generated.files && generated.model)
-      ? generated : null;
+  /** @param provider  () => { files, model } | { problem } | null */
+  PlaygroundHost.prototype.setGenerated = function (provider) {
+    this._generated = (typeof provider === 'function') ? provider : null;
   };
 
   /* ----------------------- context menu ----------------------- */

--- a/web/viz.js
+++ b/web/viz.js
@@ -367,16 +367,17 @@ define([
     },
 
     /**
-     * Hand over what the page has just generated -- the files and
-     * the model they came from -- so the code editor can show a
-     * snippet inside the function it ends up in. Kept across mounts:
-     * the model being redrawn does not make the last generation less
-     * true than it was.
+     * How the code editor gets generated code to frame a snippet
+     * with. A FUNCTION, called when a snippet is opened, so the page
+     * can answer for the model as it stands at that moment rather
+     * than as it stood when Generate was last pressed.
      *
-     * @param next  { files, model }
+     * Kept across mounts, since it does not belong to any one of them.
+     *
+     * @param provider  () => { files, model } | { problem } | null
      */
-    setGenerated: function (next) {
-      generated = next || null;
+    setGenerated: function (provider) {
+      generated = (typeof provider === 'function') ? provider : null;
       if (host) host.setGenerated(generated);
     },
 


### PR DESCRIPTION
Fixes the reported problem: edit the model, open a guard or an entry action, and the surrounding context is wrong — or missing entirely.

## Why it happened

The frame was built from whatever **Generate** last produced. So:

- **Edit anything** → the frame still showed the old surroundings.
- **Add a state, open its Entry** → *no frame at all*. That state was in no generated file yet, so there was nothing to find — and nothing said so.

Knowing to press Generate first was something you had to be told. That's training, not a tool.

## The premise was also wrong

I tied the frame to a button press because generating was "the slow half" and the user should say when. Measured:

| | C++ only | everything (test bench + Mermaid/PlantUML/SCXML) |
| --- | --- | --- |
| Simple | 7.3 ms | 4.8 ms |
| Complex | 4.2 ms | 6.2 ms |

It's free. There was never a trade-off to make.

## What changed

`generated()` is now a **function the host calls when a snippet is opened**, and the playground answers for the model in the editor *at that moment* — rendering if it must, cached against the model text so opening ten snippets renders once. It's quiet: no file list, no status, no diagnostics. Pressing Generate is still how you get files to read and download; this is a private render nobody sees.

## It always says something now

Three different things meant "no frame" and looked identical. Each now gives its reason:

- **The host has none to offer** — WebGME, where the plugin runs on the server. Not a fault, so nothing is said.
- **The model will not generate right now** — normal half-way through an edit. The editor shows the checker's own message.
- **This snippet is emitted nowhere** — a disabled transition, or a state nothing reaches.

## Also: the frames are syntax highlighted now

Requested on top of the fix. The frame is generated C++ — a signature, then a column of `[[maybe_unused]] auto &x = _root->x;` aliases — and as one flat grey block that is a lot of punctuation to read, when those aliases are the part people opened the editor to read.

They are tokenized now, on a **muted palette** against the shaded ground. The frame still reads as context: what marks it not-editable is the background, the dashed separators and the white editor between them — it never needed to be unreadable as well. The same token type keeps the same hue in both, just quieter in the frame (a string is red in the editor, dark blue above it).

`runMode` rather than a second CodeMirror instance: it tokenizes a string into a plain element, so there is no cursor, no gutter and no second copy of the document. It falls back to plain text before the library arrives and if it never does — which is also what the first paint uses, since the frames are filled before CodeMirror resolves.

The addon is vendored for the playground (WebGME already has it), and `verify-web-build` asserts it is in the built tree.

Checked in the browser: 83 tokens across seven token types in one frame, with the editable line still reading as the primary thing on screen.

## A trap this exposed

Writing the regression test turned up *why* the missing-frame case is so easy to hit:

> `Timer Period` defaults to **0** in the metamodel, and `checkModel` requires a leaf state to have **more than 0**.

So a state straight from the palette makes the **whole model** fail to generate until you set one. That's upstream of this feature and I haven't changed it — changing the default means changing the WebGME metamodel and reseeding, which is your call. But it's now *visible* (the editor shows the reason) instead of silent, and there's a test pinning the behaviour so a future fix is deliberate.

Worth considering separately: either default new states to a usable period, or let `0` mean "no timer" in the checker.

## Verification

- `npm test` — 245 passing (7 new), including the reported case end to end: add a state, get nothing from the stale generation, get a correctly framed `void Root::Recovering::entry` from a fresh one
- A test asserting generation stays under 250 ms, since "it's cheap" is the whole basis for doing it on demand
- `verify-web-build` — 72 files byte-identical; the built playground parses and the provider is wired through `app.js` → `viz.js` → `host.js`

### Verified in the browser

Chrome came back, so this is now checked by hand as well, on the Complex example with **Generate never pressed after the edits**:

| | result |
| --- | --- |
| Add a state, open its Entry | framed — `void Root::Recovering::entry ( void ) {`, at `Complex_generated_states.cpp:2533`. Previously: no frame at all. |
| Change a guard to `someNumber > 4242`, open it | frame contains the new guard, not the old `someNumber < someValue` — so it came from a fresh render |
| Drop a state with the palette default (`Timer Period: 0`) | no frame, and the header says *"The model does not generate right now: ERROR: /c/FRESH has invalid Timer Period: 0. Leaf states must have a finite numeric timer period greater than zero."* |
| Set that timer period to 1 | the frame comes straight back |
| Press Generate | unchanged — 12 files, full list, as before |

That third row is the one worth looking at: it turns the trap into instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4hRq1q5VGPjNn2dnkkqBy

