### PR TITLE
Let a URL say which machine to show, and embed the playground

### DIFF
--- a/docs/PLAYGROUND.md
+++ b/docs/PLAYGROUND.md
@@ -255,6 +255,48 @@ both together, because files paired with the wrong model produce a
 frame that is fiction. It is a function rather than a value precisely
 so the answer can be about the model at the moment it is asked for.
 
+## Linking to it, and embedding it
+
+The playground reads four query parameters, so another site can point
+at a particular machine rather than at a blank page:
+
+| parameter | does |
+| --- | --- |
+| `?example=<name>` | loads one of the bundled models (`Simple`, `Medium`, `Complex`, `basic`, `features`, `payloads`). Case and a `.json` suffix are both ignored. |
+| `?model=<url>` | loads a model from anywhere that serves it with `Access-Control-Allow-Origin`. Only `http` and `https` -- a `javascript:` or `data:` URL is refused, because a link is the one part of this someone else writes. |
+| `?view=diagram` | opens on the diagram instead of the code. |
+| `?embed=1` | drops the title, tagline and repo link, and adds a link back to the full page. Everything that does work stays. |
+
+So a project that generates its state machine from a model in its own
+repository can link straight to it:
+
+```
+https://finger563.github.io/webgme-hfsm/?model=https://example.org/hfsm/Machine.json&view=diagram
+```
+
+or put it in the page:
+
+```html
+<iframe
+  src="https://finger563.github.io/webgme-hfsm/?model=https://example.org/hfsm/Machine.json&view=diagram&embed=1"
+  width="100%" height="600" style="border: 1px solid #d0d7de; border-radius: 6px"
+  title="The Machine HFSM, in the HFSM Playground"></iframe>
+```
+
+The embedded page is the tool, not a picture of it: whoever is reading
+the documentation can drive the simulator, read the generated C++ and
+download it, all without leaving the page or installing anything.
+
+A link wins **once**. Open one, edit the model, refresh, and your
+edits come back rather than the link overwriting them -- after the
+first visit the tab's own draft takes over. Opening the same link in
+a new tab starts from the model again.
+
+If a link cannot be followed -- an example that does not exist, a
+refused URL, a model the other site does not allow this page to read
+-- the reason is shown and nothing is generated, rather than silently
+showing whatever was there before.
+
 ## Comparing two machines
 
 **Compare…** on the Diagram tab puts a second model beside the one in

--- a/test/urlRequest.spec.js
+++ b/test/urlRequest.spec.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * The query string the playground answers to: ?example=, ?model=,
+ * ?view= and ?embed=. This is the surface another site links to --
+ * espp's docs pointing at a machine, as a link or in an iframe -- so
+ * it is also the surface a link can lie about.
+ *
+ * `web/app.js` is an IIFE rather than a module, so these lift the
+ * functions out of the shipped source and exercise them directly.
+ * Testing a copy would only prove the copy works; the browser covers
+ * the parts that need a DOM.
+ */
+
+var assert = require('chai').assert;
+var fs = require('fs');
+var path = require('path');
+
+var repoRoot = path.resolve(__dirname, '..');
+var source = fs.readFileSync(path.join(repoRoot, 'web/app.js'), 'utf8');
+
+/** pull one top-level `function name(...) {...}` out of the IIFE */
+function lift(name) {
+  var start = source.indexOf('\n  function ' + name + '(');
+  assert.notStrictEqual(start, -1, 'web/app.js no longer defines ' + name);
+  var open = source.indexOf('{', start);
+  var depth = 0;
+  for (var i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}' && --depth === 0) {
+      /* jshint evil:true */
+      return new Function('window', 'EXAMPLES',
+        source.slice(start, i + 1) + '\nreturn ' + name + ';')(
+        { location: { href: 'https://finger563.github.io/webgme-hfsm/' } },
+        [
+          { label: 'Simple', file: 'examples/Simple.json' },
+          { label: 'Complex', file: 'examples/Complex.json' },
+          { label: 'Basic', file: 'examples/basic.json' },
+        ]);
+    }
+  }
+  throw new Error('unbalanced braces reading ' + name);
+}
+
+describe('what the URL asks the playground for', function() {
+
+  describe('safeModelUrl', function() {
+    var safeModelUrl = lift('safeModelUrl');
+
+    it('takes an http(s) model from anywhere', function() {
+      // the point of the parameter: espp's docs linking at a model
+      // that lives in espp's repo, not in this one
+      assert.strictEqual(
+        safeModelUrl('https://esp-cpp.github.io/espp/hfsm/Complex.json'),
+        'https://esp-cpp.github.io/espp/hfsm/Complex.json');
+      assert.strictEqual(safeModelUrl('http://localhost:8080/m.json'),
+                         'http://localhost:8080/m.json');
+    });
+
+    it('resolves a relative model against the page', function() {
+      assert.strictEqual(safeModelUrl('examples/Simple.json'),
+                         'https://finger563.github.io/webgme-hfsm/examples/Simple.json');
+    });
+
+    it('refuses anything that is not http(s)', function() {
+      // A link is the one part of this an attacker writes. `javascript:`
+      // and `data:` would turn "open this diagram" into "run this".
+      ['javascript:alert(1)',
+       'JaVaScRiPt:alert(1)',
+       'data:application/json,{}',
+       'file:///etc/passwd',
+       'vbscript:msgbox(1)',
+      ].forEach(function(bad) {
+        assert.isNull(safeModelUrl(bad), bad + ' must be refused');
+      });
+    });
+
+    it('refuses what does not parse', function() {
+      assert.isNull(safeModelUrl('http://['));
+    });
+  });
+
+  describe('exampleNamed', function() {
+    var exampleNamed = lift('exampleNamed');
+
+    it('finds a bundled example by name', function() {
+      assert.strictEqual(exampleNamed('Complex').file, 'examples/Complex.json');
+    });
+
+    it('does not care about case or a .json suffix', function() {
+      // ?example=complex and ?example=Complex.json are the same ask,
+      // and a link that guesses wrong is a link that looks broken
+      assert.strictEqual(exampleNamed('complex').file, 'examples/Complex.json');
+      assert.strictEqual(exampleNamed('COMPLEX').file, 'examples/Complex.json');
+      assert.strictEqual(exampleNamed('Complex.json').file, 'examples/Complex.json');
+    });
+
+    it('is null for one that is not bundled', function() {
+      assert.isNull(exampleNamed('NotAThing'));
+      assert.isNull(exampleNamed('../../etc/passwd'));
+    });
+  });
+});

--- a/web/app.css
+++ b/web/app.css
@@ -734,3 +734,11 @@ select:focus-visible,
   white-space: nowrap;
 }
 .popout:hover { text-decoration: underline; }
+/* in an embed this is the only link on the page, and the only way to
+   reach the full one -- it has to be obvious when tabbed to */
+.popout:focus-visible {
+  text-decoration: underline;
+  outline: 2px solid #9dc7ff;
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/web/app.css
+++ b/web/app.css
@@ -708,3 +708,29 @@ select:focus-visible,
 }
 .compare-menu button:hover,
 .compare-menu button:focus { background: #f6f8fa; outline: none; }
+
+/* ---------------------------------------------------------------- */
+/* Embedded in someone else's page (?embed=1).                       */
+/*                                                                   */
+/* Only the branding goes: inside an iframe the title and the repo   */
+/* link belong to the host page, and the vertical space is worth     */
+/* more than they are. Everything that does work stays, so the       */
+/* embed is the tool rather than a picture of it.                    */
+.is-embedded .brand,
+.is-embedded .tagline,
+.is-embedded .repo { display: none; }
+
+.is-embedded .topbar {
+  padding: 4px 10px;
+  min-height: 0;
+  justify-content: flex-end;
+}
+
+/* the way back to the full page, which an iframe otherwise hides */
+.popout {
+  color: #9dc7ff;
+  text-decoration: none;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.popout:hover { text-decoration: underline; }

--- a/web/app.js
+++ b/web/app.js
@@ -104,6 +104,63 @@
     { label: 'Payloads (typed event data)', file: 'examples/payloads.json' },
   ];
 
+  /* --------------------- what the URL asked for --------------------- */
+
+  var APPLIED_KEY = 'hfsm-playground:from-url';
+
+  /**
+   * What the query string is asking the page to show.
+   *
+   *   ?example=Complex     one of the bundled models, by name
+   *   ?model=<url>         a model fetched from anywhere CORS allows
+   *   ?view=diagram|code   which tab to open
+   *   ?embed=1             drop the page chrome, for an <iframe>
+   *
+   * This is how another site links to a specific machine -- espp's
+   * docs pointing at the state machine its example generates from,
+   * say -- either as a link or embedded in the page.
+   */
+  function urlRequest() {
+    var q;
+    try {
+      q = new URLSearchParams(window.location.search);
+    } catch (e) {
+      return null;      // no URLSearchParams: nothing to honour
+    }
+    var req = {
+      example: q.get('example'),
+      model: q.get('model'),
+      view: q.get('view'),
+      embed: q.get('embed') === '1' || q.get('embed') === 'true',
+    };
+    return (req.example || req.model || req.view || req.embed) ? req : null;
+  }
+
+  /** the bundled example called `name`, matched loosely on purpose */
+  function exampleNamed(name) {
+    var want = String(name).replace(/[.]json$/i, '').toLowerCase();
+    for (var i = 0; i < EXAMPLES.length; i++) {
+      var base = EXAMPLES[i].file.split('/').pop().replace(/[.]json$/i, '');
+      if (base.toLowerCase() === want) return EXAMPLES[i];
+    }
+    return null;
+  }
+
+  /**
+   * Only http(s), and only absolute. `javascript:` and `data:` URLs
+   * would be a way to smuggle something executable through a link
+   * that otherwise looks like it just opens a diagram.
+   */
+  function safeModelUrl(raw) {
+    var url;
+    try {
+      url = new URL(raw, window.location.href);
+    } catch (e) {
+      return null;
+    }
+    return (url.protocol === 'https:' || url.protocol === 'http:') ? url.href : null;
+  }
+
   /* ------------------------ how it is laid out ---------------------- */
 
   /**
@@ -157,6 +214,12 @@
   var SAVE_DELAY = 400;
   var draftTimer = null;
   var restoredDraft = null;   // what this tab came back to, if anything
+  // a URL-requested model that arrived before the generator did
+  var pendingRequest = null;
+  // why a URL request was refused, held until the generator has
+  // finished booting -- restoring the draft generates, and generating
+  // clears the diagnostics, so saying it at the time says nothing
+  var requestProblem = null;
 
   function writeDraft() {
     draftTimer = null;
@@ -224,10 +287,110 @@
     return true;
   }
 
+  /**
+   * Load what the URL asked for. Returns true when something is on
+   * its way, so boot knows not to restore the draft over it.
+   *
+   * The URL wins on the FIRST visit only. Someone who opens a link,
+   * edits the model and refreshes should get their edits back rather
+   * than have the link overwrite them -- so once a query has been
+   * applied in this tab, the draft takes over.
+   */
+  function applyRequest(req, whenLoaded) {
+    if (!req) return false;
+    if (req.embed) goEmbedded(req);
+
+    var already;
+    try {
+      already = sessionStorage.getItem(APPLIED_KEY) === window.location.search;
+    } catch (e) {
+      already = false;
+    }
+    if (already && hasDraft()) return false;   // their edits, not the link
+
+    var wanted = null;
+    if (req.example) {
+      var ex = exampleNamed(req.example);
+      if (!ex) {
+        requestProblem = ['No bundled example called "' + req.example + '".',
+                          'Available: ' + EXAMPLES.map(function (e) {
+                            return e.file.split('/').pop().replace(/[.]json$/, '');
+                          }).join(', ')];
+        return false;
+      }
+      wanted = { url: ex.file, label: ex.label };
+    } else if (req.model) {
+      var safe = safeModelUrl(req.model);
+      if (!safe) {
+        requestProblem = ['That model URL is not one this page will open: ' +
+                          req.model, 'Only http(s) URLs are loaded.'];
+        return false;
+      }
+      wanted = { url: safe, label: safe };
+    }
+    if (!wanted) return false;   // ?view= / ?embed= alone: nothing to fetch
+
+    setStatus('loading ' + wanted.label + '\u2026');
+    fetch(wanted.url).then(function (r) {
+      if (!r.ok) throw new Error(r.status + ' ' + r.statusText);
+      return r.text();
+    }).then(function (text) {
+      loadModelText(text);
+      try {
+        sessionStorage.setItem(APPLIED_KEY, window.location.search);
+      } catch (e) { /* private mode: the link just applies every time */ }
+      setStatus('loaded');
+      whenLoaded();
+    }).catch(function (err) {
+      showDiagnostics(['Could not load ' + wanted.label + ': ' + err.message,
+                       'A model on another site has to be served with ' +
+                       'Access-Control-Allow-Origin for this page to read it.'],
+                      'error');
+      setStatus('load failed', 'error');
+    });
+    return true;
+  }
+
+  /** whether this tab has a model of its own worth keeping */
+  function hasDraft() {
+    try {
+      var saved = JSON.parse(sessionStorage.getItem(DRAFT_KEY) || 'null');
+      return !!(saved && typeof saved.text === 'string' && saved.text.trim());
+    } catch (e) {
+      return false;
+    }
+  }
+
   // the textarea remains the fallback when CodeMirror is unavailable,
   // so every read/write of the model goes through these two
   function getModelText() {
     return modelEditor ? modelEditor.getValue() : el('modelInput').value;
+  }
+
+  /**
+   * Strip the page down to the tool itself, for embedding in another
+   * site's documentation. The chrome that goes is the part that only
+   * makes sense on the page's own site: the title, the tagline and
+   * the repo link. Everything that does work stays, including the
+   * example picker -- an embedded playground people cannot drive is
+   * a screenshot with extra steps.
+   *
+   * A way back out is added in its place, because inside an iframe
+   * there is otherwise no way to reach the full page.
+   */
+  function goEmbedded(req) {
+    document.documentElement.classList.add('is-embedded');
+    var header = document.querySelector('header.topbar');
+    if (!header) return;
+    var out = document.createElement('a');
+    var full = new URL(window.location.href);
+    full.searchParams.delete('embed');
+    out.href = full.href;
+    out.target = '_blank';
+    out.rel = 'noopener';
+    out.className = 'popout';
+    out.textContent = 'Open in the HFSM Playground \u2197';
+    header.appendChild(out);
   }
 
   /**
@@ -1572,11 +1735,24 @@
   readLayout();     // before anything that lays itself out
   wire();
 
-  // Bring back whatever this tab was working on. Before the generator
-  // has loaded, so the text is on screen immediately -- and quietly,
-  // because from the user's side nothing happened: they refreshed and
-  // their model is still there.
-  restoreDraft();
+  // What the URL asks for comes first: a link to a particular machine
+  // has to show that machine, not whatever this tab was last editing.
+  var request = urlRequest();
+  var fromUrl = applyRequest(request, function () {
+    // the fetch may land before or after the generator is ready
+    if (mods) {
+      generate();
+      if (request.view === 'diagram') showTab('diagram');
+    } else {
+      pendingRequest = request;
+    }
+  });
+
+  // Otherwise bring back whatever this tab was working on. Before the
+  // generator has loaded, so the text is on screen immediately -- and
+  // quietly, because from the user's side nothing happened: they
+  // refreshed and their model is still there.
+  if (!fromUrl) restoreDraft();
 
   requirejs([CM_ID].concat(CM_MODES), function (cm) {
     try {
@@ -1617,9 +1793,26 @@
     // session was not, which reads as the model not being loaded at
     // all. Generating takes well under a second for these, and it is
     // what had already happened before the refresh.
-    if (restoredDraft) {
+    if (requestProblem) {
+      // FIRST, and instead of generating. Drawing the diagram clears
+      // the diagnostics when it settles, several ticks later, so a
+      // message shown before that is wiped without ever being read --
+      // which left a mistyped link silently showing the previous
+      // model. Whatever was in the editor stays there, ungenerated,
+      // with the reason on screen and Generate one press away.
+      showDiagnostics(requestProblem, 'error');
+      setStatus('link not followed', 'error');
+      requestProblem = null;
+    } else if (restoredDraft) {
       generate();
       if (restoredDraft.tab === 'diagram') showTab('diagram');
+    } else if (pendingRequest) {
+      // the model arrived while the generator was still loading
+      generate();
+      if (pendingRequest.view === 'diagram') showTab('diagram');
+      pendingRequest = null;
+    } else if (request && request.view === 'diagram') {
+      showTab('diagram');
     }
   }, function (err) {
     showDiagnostics(['Failed to load the generator modules: ' + err.message,

--- a/web/app.js
+++ b/web/app.js
@@ -224,10 +224,14 @@
   // finished booting -- restoring the draft generates, and generating
   // clears the diagnostics, so saying it at the time says nothing
   var requestProblem = null;
-  // a link that failed while the generator was still loading: the
-  // fetch and the module load race, and whichever finishes second
-  // used to have the last word on the status line
+  // The fetch for a URL-requested model races the generator's module
+  // load, and whichever finishes second used to have the last word on
+  // the status line. Both directions were wrong: a failure announced
+  // before the modules landed was overwritten by "ready", and a fetch
+  // still in flight when they landed was ALSO called "ready" -- so a
+  // slow or hung ?model= read as finished with nothing on screen.
   var linkFailed = false;
+  var linkInFlight = false;
 
   function writeDraft() {
     draftTimer = null;
@@ -342,10 +346,12 @@
     if (!wanted) return false;   // ?view= / ?embed= alone: nothing to fetch
 
     setStatus('loading ' + wanted.label + '\u2026');
+    linkInFlight = true;
     fetch(wanted.url).then(function (r) {
       if (!r.ok) throw new Error(r.status + ' ' + r.statusText);
       return r.text();
     }).then(function (text) {
+      linkInFlight = false;
       loadModelText(text);
       try {
         sessionStorage.setItem(APPLIED_KEY, window.location.search);
@@ -358,6 +364,7 @@
                        'Access-Control-Allow-Origin for this page to read it.'],
                       'error');
       setStatus('load failed', 'error');
+      linkInFlight = false;
       linkFailed = true;
       // The link was the only reason not to restore this tab's draft,
       // and it did not arrive -- so fall back to it rather than
@@ -1801,7 +1808,10 @@
       describe: describe,
       MetaTemplates: MetaTemplates,
     };
-    if (!linkFailed) setStatus('ready');
+    // "ready" is about the generator, but it is the only thing on the
+    // status line -- so it must not claim a link that is still on its
+    // way has arrived, or overwrite one that already failed.
+    if (!linkFailed && !linkInFlight) setStatus('ready');
 
     // Put the tab back the way it was, not just the text in it.
     //

--- a/web/app.js
+++ b/web/app.js
@@ -147,9 +147,13 @@
   }
 
   /**
-   * Only http(s), and only absolute. `javascript:` and `data:` URLs
-   * would be a way to smuggle something executable through a link
-   * that otherwise looks like it just opens a diagram.
+   * Only http(s). `javascript:` and `data:` URLs would be a way to
+   * smuggle something executable through a link that otherwise looks
+   * like it just opens a diagram.
+   *
+   * Relative URLs are resolved against this page, deliberately: it is
+   * how the bundled examples are reached, and how a site that hosts
+   * both its docs and its models refers to its own.
    */
   function safeModelUrl(raw) {
     var url;
@@ -220,6 +224,10 @@
   // finished booting -- restoring the draft generates, and generating
   // clears the diagnostics, so saying it at the time says nothing
   var requestProblem = null;
+  // a link that failed while the generator was still loading: the
+  // fetch and the module load race, and whichever finishes second
+  // used to have the last word on the status line
+  var linkFailed = false;
 
   function writeDraft() {
     draftTimer = null;
@@ -263,7 +271,7 @@
   }
 
   /** @return true if a draft was restored */
-  function restoreDraft() {
+  function restoreDraft(quiet) {
     var saved = null;
     try {
       saved = JSON.parse(sessionStorage.getItem(DRAFT_KEY) || 'null');
@@ -273,7 +281,10 @@
     if (!saved || typeof saved.text !== 'string' || !saved.text.trim()) {
       return false;
     }
-    restoredDraft = saved;
+    // `quiet` restores the text without asking for a generate: the
+    // caller is a failed link, and generating clears the message
+    // saying why it failed.
+    if (!quiet) restoredDraft = saved;
     // what it was loaded from, if the draft remembered -- otherwise
     // the draft itself is the best starting point there is
     loadedText = typeof saved.loaded === 'string' ? saved.loaded : saved.text;
@@ -347,6 +358,12 @@
                        'Access-Control-Allow-Origin for this page to read it.'],
                       'error');
       setStatus('load failed', 'error');
+      linkFailed = true;
+      // The link was the only reason not to restore this tab's draft,
+      // and it did not arrive -- so fall back to it rather than
+      // leaving someone staring at an empty editor. Only when the
+      // editor is still empty: whatever is in it now is newer.
+      if (!getModelText().trim()) restoreDraft(true);
     });
     return true;
   }
@@ -1784,7 +1801,7 @@
       describe: describe,
       MetaTemplates: MetaTemplates,
     };
-    setStatus('ready');
+    if (!linkFailed) setStatus('ready');
 
     // Put the tab back the way it was, not just the text in it.
     //


### PR DESCRIPTION
The playground read **nothing** from its URL — no `location.search`, no `URLSearchParams` anywhere. The most another site could say was "open the playground, then pick Complex from the dropdown."

Four parameters make it linkable:

| parameter | does |
| --- | --- |
| `?example=<name>` | one of the bundled models, by name (case and a `.json` suffix ignored) |
| `?model=<url>` | a model from anywhere that serves it with `Access-Control-Allow-Origin` |
| `?view=diagram` | open on the diagram rather than the code |
| `?embed=1` | drop the branding, for an `<iframe>` |

```html
<iframe src="https://finger563.github.io/webgme-hfsm/?model=https://example.org/hfsm/Machine.json&view=diagram&embed=1"
        width="100%" height="600"></iframe>
```

Embedded, only the branding goes — the title, tagline and repo link belong to the host page inside an iframe. Everything that does work stays, so the embed is **the tool rather than a picture of it**: whoever is reading the docs can drive the simulator, read the generated C++ and download it. A link back to the full page replaces what was removed, since an iframe otherwise has no way out.

### A link is the one part of this someone else writes

`?model=` follows `http(s)` only. `javascript:` and `data:` would turn "open this diagram" into "run this", so they are refused — as is anything that fails to parse. Relative URLs resolve against the page.

### A link wins once

Open a link, edit the model, refresh — and the **edits** come back, not the link. After the first visit the tab's own draft takes over, keyed on the query string so a *different* link still applies. Opening the same link in a new tab starts from the model again.

### One real bug, found in the browser

My first version reported refusals and then lost them. Drawing the diagram clears the diagnostics when it settles, several ticks after generating starts — so the message was wiped before it could be read, and **a mistyped link silently showed the previous model**. Refusals now report *instead of* generating: whatever is in the editor stays there, ungenerated, with the reason on screen.

I only caught it because I loaded `?model=javascript:alert(1)` in a browser and noticed the absence of a message I had just written the code to print.

### Testing

`web/app.js` is an IIFE, so `test/urlRequest.spec.js` lifts `safeModelUrl` and `exampleNamed` out of the shipped source and exercises them directly — testing a copy would only prove the copy works. Both mutation-tested: allowing any protocol, and making the example match case-sensitive, each fail.

Verified in a browser end-to-end: `?example=Complex&view=diagram` draws; a **cross-origin** `?model=` fetched from GitHub Pages generates and draws inside `?embed=1`; both refusal paths show their message; and the edit-then-refresh case keeps the edit.

275 → 282 tests. `verify:web` 72 files identical.