### PR TITLE
A state cannot have Initialization, so stop pretending it can

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,8 +657,10 @@ State Machines have the following attributes:
 
 * `Includes` : include statements for the HFSM, will be at the top of
   the generated header
-* `Initialization` : initialization code run at the beginning of the
-  HFSM, before any of the state initialization code.
+* `Initialization` : initialization code run once at the beginning of
+  the HFSM, before any state is entered. This is a State Machine
+  attribute only -- a *state* has no initialization step of its own:
+  use `Entry`, which runs each time the state becomes active.
 * `Declarations` : variable/function/class declarations within the
   HFSM's `StateMachine` namespace, will be within the generated header
   file

--- a/src/common/checkModel.js
+++ b/src/common/checkModel.js
@@ -590,7 +590,7 @@ define(['./viz/describe', './metaRules'], function(describe, metaRules) {
           // checks:
           // * name is good,
           // * name is unique within siblings
-          // * cannot have 'Includes' set
+          // * cannot have 'Includes' or 'Initialization' set
           // * must have 'Initial' if there are children
           // * can only one 'Initial'
           // * must have transition path from 'Initial' to a child state if 'Initial' exists
@@ -600,10 +600,22 @@ define(['./viz/describe', './metaRules'], function(describe, metaRules) {
           // * timer period is non-zero if it has no child states
           self.checkName( obj );
           var parentObj = model.objects[obj.parentPath];
-          // cannot have includes set
-          if ((obj.Includes || '').trim().length > 0) {
-            self.error(obj, "States cannot have 'Includes'");
-          }
+          // Attributes a State inherits but cannot use. The list and
+          // the advice live in `describe` because the inspector uses
+          // the same table to decide not to OFFER these fields -- a
+          // model can still arrive with one set (hand-written, or made
+          // before the field was hidden), so it is still checked here.
+          //
+          // 'Initialization' was neither offered-and-refused nor
+          // emitted before this: the templates never rendered it, so
+          // code written into it ran nowhere and nothing said so.
+          var rejected = describe.rejectedAttributes(obj.type);
+          Object.keys(rejected).forEach(function(attribute) {
+            if ((obj[attribute] || '').trim().length > 0) {
+              self.error(obj, "States cannot have '" + attribute + "' -- " +
+                         rejected[attribute]);
+            }
+          });
           // make sure no direct siblings of this state share its name
           obj.parentState = null;
           if (parentObj && parentObj.type != 'Project') {

--- a/src/common/viz/describe.js
+++ b/src/common/viz/describe.js
@@ -41,6 +41,32 @@ define(['../metaRules'], function (metaRules) {
   ];
 
   /**
+   * Attributes a type carries in the metamodel but cannot use.
+   *
+   * A State inherits these from State Machine Base, and neither has
+   * anywhere to go:
+   *
+   *  - Includes belong to the State Machine's header, not to one of
+   *    its states.
+   *  - Initialization has no moment in a state's life that it could
+   *    mean. A state's initialize() runs when the state becomes
+   *    ACTIVE -- which is exactly when Entry runs -- and the HFSM
+   *    does not initialize every state up front. Two hooks for one
+   *    moment, one with clear UML semantics and one without, is
+   *    worse than one.
+   *
+   * The value here is the advice to give when a model sets one
+   * anyway, so the checker's message and this panel's decision not
+   * to offer the field come from the same place.
+   */
+  var REJECTED_ATTRIBUTES = {
+    'State': {
+      'Includes': "includes belong to the State Machine, not to a state",
+      'Initialization': "use 'Entry', which runs when the state becomes active",
+    },
+  };
+
+  /**
    * Attributes that hold long-form TEXT rather than a value or code.
    *
    * `documentation` is markdown a person writes paragraphs in. It is
@@ -90,6 +116,12 @@ define(['../metaRules'], function (metaRules) {
     ROOT_TYPES: ROOT_TYPES,
     NON_GRAPH_TYPES: NON_GRAPH_TYPES,
     CODE_ATTRIBUTES: CODE_ATTRIBUTES,
+    REJECTED_ATTRIBUTES: REJECTED_ATTRIBUTES,
+
+    /** what `type` may not set, as {attribute: why} */
+    rejectedAttributes: function (type) {
+      return REJECTED_ATTRIBUTES[type] || {};
+    },
     PROSE_ATTRIBUTES: PROSE_ATTRIBUTES,
     IDENTIFIER_ATTRIBUTES: IDENTIFIER_ATTRIBUTES,
 
@@ -152,6 +184,13 @@ define(['../metaRules'], function (metaRules) {
       if (labelledByEvent(schema)) {
         attributes = attributes.filter(function (a) { return a.name !== 'name'; });
       }
+      // Not offered at all, rather than offered and then refused.
+      // A field whose every value is an error is a worse way to say
+      // "this does not apply here" than simply not being there --
+      // and Initialization was worse still, because nothing rejected
+      // it and nothing emitted it, so code written in it ran nowhere.
+      var rejected = REJECTED_ATTRIBUTES[schema && schema.name] || {};
+      attributes = attributes.filter(function (a) { return !rejected[a.name]; });
       return this.fieldOrder(attributes);
     },
 

--- a/test/attributeReach.spec.js
+++ b/test/attributeReach.spec.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * Every code attribute a model can set must either REACH the
+ * generated output or be REFUSED. The third option -- accepted,
+ * stored, and silently dropped -- is the one this file exists to
+ * stop, because nothing else could see it.
+ *
+ * `State . Initialization` was in exactly that state. A state
+ * inherits the attribute from State Machine Base, no template ever
+ * rendered it, and no rule rejected it: code typed into it was saved
+ * in the model, generated nothing, and said nothing. The inspector
+ * even reported the truth -- "not emitted in the generated code" --
+ * which read as a bug in the inspector rather than in the generator.
+ *
+ * The sweep below finds that class of fault rather than that one
+ * instance of it.
+ */
+
+var assert = require('chai').assert;
+var fs = require('fs');
+var path = require('path');
+
+var amdLoader = require('../bin/amd-loader');
+var repoRoot = path.resolve(__dirname, '..');
+
+// identifiers and numbers: constrained elsewhere, and stamping a
+// comment into them is not a meaningful question
+var NOT_CODE = ['name', 'Event', 'namespace', 'Timer Period'];
+
+describe('what a model can set, the generator must use or refuse', function() {
+  var mods = {};
+  var meta;
+
+  before(function() {
+    meta = JSON.parse(fs.readFileSync(
+      path.join(repoRoot, 'src/common/meta.json'), 'utf8'));
+    return amdLoader.load([
+      'src/common/resolveModel',
+      'src/common/processor',
+      'src/common/checkModel',
+      'src/plugins/SoftwareGenerator/templates/MetaTemplates',
+    ]).then(function(loaded) {
+      mods.resolveModel = loaded[0];
+      mods.processor = loaded[1];
+      mods.checkModel = loaded[2];
+      mods.MetaTemplates = loaded[3];
+    });
+  });
+
+  /**
+   * Generate, or report why the model was refused.
+   *
+   * Only a MODEL error counts as a refusal. An earlier version of this
+   * caught everything, so a typo in the harness (resolveModel.resolve
+   * is not resolveModel.resolveModel) made every model look refused
+   * and the sweep passed without ever generating anything.
+   */
+  function render(model) {
+    var copy = JSON.parse(JSON.stringify(model));
+    try {
+      mods.resolveModel.resolve(copy);
+      mods.processor.processModel(copy);
+    } catch (e) {
+      var text = (e && e.message) || String(e);
+      if (e instanceof TypeError || /is not a function/.test(text)) throw e;
+      return { refused: text };
+    }
+    var out = {};
+    Object.assign(out, mods.MetaTemplates.renderHFSM(copy, 'test_ns'));
+    Object.assign(out, mods.MetaTemplates.renderTestCode(copy, 'test_ns'));
+    return { text: Object.keys(out).map(function(f) { return out[f]; }).join('\n') };
+  }
+
+  var FIXTURE = 'examples/Complex.json';
+
+  it('leaves no code attribute both accepted and unused', function() {
+    var base = JSON.parse(fs.readFileSync(path.join(repoRoot, FIXTURE), 'utf8'));
+    var types = meta.types || meta;
+
+    // every (type, attribute) this fixture can actually exercise
+    var pairs = {};
+    Object.keys(base.objects).forEach(function(objPath) {
+      var obj = base.objects[objPath];
+      var declared = (types[obj.type] || {}).attributes || {};
+      Object.keys(declared).forEach(function(attribute) {
+        if (declared[attribute].type !== 'string') return;
+        if (NOT_CODE.indexOf(attribute) > -1) return;
+        var key = obj.type + '|' + attribute;
+        (pairs[key] = pairs[key] || []).push(objPath);
+      });
+    });
+    assert.isAbove(Object.keys(pairs).length, 10,
+      'the fixture should cover a good spread of attributes');
+
+    var dropped = [];
+    Object.keys(pairs).sort().forEach(function(key) {
+      var parts = key.split('|'), attribute = parts[1];
+      var model = JSON.parse(JSON.stringify(base));
+      var stamp = 'ZQ' + attribute.replace(/[^A-Za-z]/g, '') + 'ZQ';
+      pairs[key].forEach(function(objPath) {
+        var obj = model.objects[objPath];
+        var had = typeof obj[attribute] === 'string' && obj[attribute].trim();
+        obj[attribute] = (had ? obj[attribute] + '\n' : '') + '// ' + stamp;
+      });
+
+      var result = render(model);
+      if (result.refused) return;                    // refused: said so
+      if (result.text.indexOf(stamp) > -1) return;   // emitted: used
+      dropped.push(key.replace('|', ' . '));
+    });
+
+    assert.deepEqual(dropped, [],
+      'these are accepted by the checker and never reach the generated ' +
+      'code, so anything written in them runs nowhere: ' + dropped.join(', '));
+  });
+});

--- a/test/createDialog.spec.js
+++ b/test/createDialog.spec.js
@@ -119,6 +119,32 @@ describe('the create dialog', function () {
     });
   });
 
+  it('does not offer a state the fields it is not allowed to set',
+     function () {
+    // Includes and Initialization are inherited from State Machine
+    // Base and rejected by the checker for states. A field whose every
+    // value is an error is a worse way to say "not here" than not
+    // being there -- and Initialization was worse again, because
+    // nothing rejected it and nothing emitted it, so text typed in it
+    // was saved and then ran nowhere.
+    var offered = describeMod.editableAttributes(forType('State').getCurrentSchema())
+      .map(function (a) { return a.name; });
+
+    assert.ok(offered.indexOf('Initialization') === -1,
+      'a state cannot run Initialization, so it should not be offered');
+    assert.ok(offered.indexOf('Includes') === -1,
+      'a state cannot set Includes, so it should not be offered');
+    assert.ok(offered.indexOf('Entry') > -1,
+      'Entry is what a state should use instead, and must still be there');
+
+    // and the machine, which CAN use both, keeps them
+    var machine = describeMod.editableAttributes(
+      forType('State Machine').getCurrentSchema())
+      .map(function (a) { return a.name; });
+    assert.ok(machine.indexOf('Initialization') > -1);
+    assert.ok(machine.indexOf('Includes') > -1);
+  });
+
   it('gives code and prose room, and a one-line input to everything else',
      function () {
        var dialog = forType('State');

--- a/test/generator.spec.js
+++ b/test/generator.spec.js
@@ -148,6 +148,40 @@ describe('hfsm generator', function() {
       }, /invalid name/);
     });
 
+    it('rejects Initialization on a state, pointing at Entry', function() {
+      // A state inherits the attribute from State Machine Base and has
+      // nowhere to run it: initialize() happens when the state becomes
+      // active, which is what Entry already means. Before this it was
+      // neither refused nor emitted -- code written into it ran
+      // nowhere, and nothing anywhere said so.
+      expectModelError('basic', function(objects) {
+        objects['/p/m/Idle'].Initialization = 'setup();';
+      }, /States cannot have 'Initialization'.*use 'Entry'/);
+    });
+
+    it('still rejects Includes on a state', function() {
+      expectModelError('basic', function(objects) {
+        objects['/p/m/Idle'].Includes = '#include <cstdio>';
+      }, /States cannot have 'Includes'/);
+    });
+
+    it('leaves Initialization alone on the State Machine, where it runs',
+       function() {
+      // the rejection is per-type: the machine's own Initialization is
+      // the one real use of the attribute
+      var model = loadFixture('basic');
+      var machine = Object.keys(model.objects).filter(function(p) {
+        return model.objects[p].type === 'State Machine';
+      })[0];
+      model.objects[machine].Initialization = '// ZQROOTINITZQ';
+      mods.resolveModel.resolve(model);
+      mods.processor.processModel(model);
+      var out = mods.MetaTemplates.renderHFSM(model, NAMESPACE);
+      var all = Object.keys(out).map(function(f) { return out[f]; }).join('\n');
+      assert.ok(all.indexOf('ZQROOTINITZQ') > -1,
+                "the machine's Initialization should still be emitted");
+    });
+
     it('rejects events on transitions out of choice pseudostates', function() {
       expectModelError('features', function(objects) {
         objects['/p/m/c1'].Event = 'SNEAKY';


### PR DESCRIPTION
Typing initialization code into a state saved it in the model and **generated nothing**. No template ever rendered `State.Initialization` — a state inherits the attribute from State Machine Base — and no rule rejected it, so the code ran nowhere and nothing said so.

The inspector's *"Not emitted in the generated code — a disabled transition, or a state nothing reaches"* was reporting that accurately. It just read as a bug in the inspector, because the explanation it offered was the wrong one.

### Emitting it would have been the wrong fix

My first attempt did exactly that, and it was wrong: a state's `initialize()` runs when the state becomes **active**, which is precisely when `Entry` runs, and the HFSM doesn't initialize every state up front. That would have added a second entry action with murkier semantics beside one with clear UML meaning. (Verified the ordering by compiling and running it — root init, then parent state, then substate — which is what made it obvious it was just `Entry` again.)

So: the field is no longer **offered** for states, and a model that carries one anyway is refused with advice to use `Entry`.

`Includes` joins it in the same table. It was already refused, but still offered — so the only way to find out it was wrong was to generate.

The table lives in `describe` because the panel and the checker have to agree about it. A field that is offered and always refused is a worse way to say "not here" than a field that isn't there.

### The general form

`test/attributeReach.spec.js` sweeps every `(type, attribute)` pair a fixture can exercise and asserts each one either **reaches the generated output** or is **refused**. Accepted-and-silently-dropped is the state this bug lived in, and nothing was watching for it. Running the sweep against the old code names exactly one thing: `State . Initialization`.

That test was worthless on its first draft, which is worth recording: I'd called `resolveModel.resolveModel` (the API is `.resolve`), the resulting `TypeError` was swallowed by a catch-all that treated any throw as "the model was refused", and so every pair looked refused and the sweep passed while detecting nothing. It now rethrows harness errors and only counts genuine model errors as refusals.

### Not done, deliberately

Removing the `RootAliases` block from state `initialize()` was considered — if no user code lands there, the aliases are dead weight. **They are not dead.** `initialize()` renders the initial transition's `Action` and `Guard`, both user code, both able to reference HFSM variables by bare name. Removing the aliases and compiling gives:

```
error: use of non-static data member 'cycle' of 'Root' from nested type 'Child2'
```

so they stay.

### Checks

287 tests (up from 282). Goldens unchanged — this adds no output. All six fixtures compile under `-Werror` with ASan/UBSan and their traces match. `verify:web` 72 files identical. Each new test was mutation-tested; the README's claim that the machine's `Initialization` runs "before any of the state initialization code" is corrected, since there is no such thing.