### PR TITLE
Add --no-support, for projects that vendor the runtime already

### DIFF
--- a/bin/hfsm-gen.js
+++ b/bin/hfsm-gen.js
@@ -16,6 +16,11 @@
  *   -e, --export <fmts>    comma-separated interop exports:
  *                          mermaid, plantuml, scxml (or 'all')
  *       --no-code          skip C++ code generation (exports only)
+ *       --no-support       skip the support headers that are the same
+ *                          for every machine (state_base.hpp,
+ *                          deep_history_state.hpp,
+ *                          shallow_history_state.hpp, magic_enum.hpp)
+ *                          -- for projects that already vendor them
  *   -h, --help             show this help
  *
  * The model JSON format is the webgme-to-json format; see
@@ -50,6 +55,7 @@ var args = process.argv.slice(2);
 var opts = {
   input: null,
   out: 'generated',
+  support: true,   // emit the shared runtime headers alongside the machine
   namespace: null, // -n flag > model.namespace > 'state_machine'
   testBench: false,
   exports: [],
@@ -65,6 +71,7 @@ for (var i = 0; i < args.length; i++) {
     opts.exports = opts.exports.concat((args[++i] || '').split(','));
   }
   else if (a === '--no-code') opts.code = false;
+  else if (a === '--no-support') opts.support = false;
   else if (a[0] === '-') fail("unknown option '" + a + "' (see --help)");
   else if (!opts.input) opts.input = a;
   else fail('multiple input files given');
@@ -138,6 +145,23 @@ amdLoader.load([
     if (opts.code) {
       Object.assign(artifacts,
                     MetaTemplates.renderHFSM(model, opts.namespace));
+      if (!opts.support && opts.testBench) {
+        // The bench is meant to build on its own, and it cannot
+        // without these -- verified: the Makefile stops at
+        // 'deep_history_state.hpp' file not found.
+        console.error("hfsm-gen: warning: --no-support with --test-bench: " +
+                      "the generated Makefile expects the support headers, " +
+                      "so supply your own copies or drop --no-support.");
+      }
+      if (!opts.support) {
+        // Asked for, not filtered by name here: a project that vendors
+        // this runtime already -- espp's state_machine component, say
+        // -- needs its OWN copies on the include path, and a second
+        // set beside the generated machine would shadow them.
+        MetaTemplates.supportFileNames().forEach(function(fname) {
+          delete artifacts[fname];
+        });
+      }
       if (opts.testBench) {
         Object.assign(artifacts,
                       MetaTemplates.renderTestCode(model, opts.namespace));

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -144,6 +144,34 @@ npm install --no-save --ignore-scripts requirejs requirejs-text handlebars under
 These are the CLI's real dependencies, and they are what `npm install
 webgme-hfsm` brings with it.
 
+## Generating only the machine
+
+By default the generator emits the machine *and* the small runtime it
+depends on — `state_base.hpp`, `deep_history_state.hpp`,
+`shallow_history_state.hpp` and `magic_enum.hpp`. Those four are the
+same for every machine.
+
+A project that already vendors that runtime wants the other three
+files and not these, because its own copies are the ones the rest of
+its code is built against — a second `state_base.hpp` beside the
+generated machine lands on the include path and shadows them:
+
+```sh
+hfsm-gen my_machine.json -o generated --no-support
+```
+
+The machine itself is byte-for-byte the same either way; the flag
+decides what gets written, not what gets rendered.
+
+`--test-bench` expects the support headers (its Makefile builds
+standalone), so asking for both warns.
+
+[espp's `state_machine` example][espp] uses this from CMake: the model
+is checked in, the C++ is generated at build time, and the runtime
+comes from the component rather than from the generator.
+
+[espp]: https://github.com/esp-cpp/espp/tree/main/components/state_machine/example
+
 ## Model JSON format
 
 The input is the `webgme-to-json` format: a map of objects keyed by

--- a/src/plugins/SoftwareGenerator/templates/MetaTemplates.js
+++ b/src/plugins/SoftwareGenerator/templates/MetaTemplates.js
@@ -119,6 +119,16 @@ define(['bower/handlebars/handlebars.min',
              });
              return artifacts;
            },
+           /**
+            * The files that are the same runtime for every machine,
+            * rather than anything about a particular one. Exposed so
+            * a caller that already vendors this support library can
+            * ask for its names instead of knowing them.
+            */
+           supportFileNames: function() {
+             return UMLTemplates.supportFileNames();
+           },
+
            renderHFSM: function(model, namespace, objToFilePrefixFn ) {
              var self    = this;
              var objects = model.objects;

--- a/src/plugins/SoftwareGenerator/templates/uml/Templates.js
+++ b/src/plugins/SoftwareGenerator/templates/uml/Templates.js
@@ -78,6 +78,18 @@ define(['bower/handlebars/handlebars.min',
              "GeneratedStatesTemplHpp",
              "GeneratedStatesTemplCpp" ];
 
+         // The templates that are the same runtime for every machine
+         // rather than anything about THIS one. A project that already
+         // vendors this support library -- espp's state_machine
+         // component does -- wants the other three files and not
+         // these, because its own copies are the ones the rest of its
+         // code is built against.
+         var supportTemplates = [
+           "StateBaseData",
+           "DeepHistoryData",
+           "ShallowHistoryData",
+         ];
+
          var keyTemplates = {
            'StateBaseData': 'state_base.hpp',
            'DeepHistoryData': 'deep_history_state.hpp',
@@ -315,6 +327,19 @@ define(['bower/handlebars/handlebars.min',
          return {
            renderStatic: function() {
              return staticFiles;
+           },
+
+           /**
+            * The files that are the same for every machine.
+            *
+            * Derived from the template tables rather than listed
+            * again: a support template added above appears here
+            * without anyone remembering to.
+            */
+           supportFileNames: function() {
+             return supportTemplates.map(function(key) {
+               return keyTemplates[key];
+             }).concat(Object.keys(staticFiles));
            },
            renderStates: function(root) {
              var rendered = {};

--- a/test/hfsmGenCli.spec.js
+++ b/test/hfsmGenCli.spec.js
@@ -39,6 +39,11 @@ describe('hfsm-gen --no-support', function() {
     full = run([]);
     lean = run(['--no-support']);
   });
+  after(function() {
+    [full, lean].forEach(function(r) {
+      if (r && r.dir) fs.rmSync(r.dir, { recursive: true, force: true });
+    });
+  });
 
   it('leaves out the files that are the same for every machine', function() {
     ['state_base.hpp', 'deep_history_state.hpp',

--- a/test/hfsmGenCli.spec.js
+++ b/test/hfsmGenCli.spec.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * `--no-support` on the generator CLI.
+ *
+ * A project that already vendors the HFSM runtime -- espp's
+ * state_machine component is the reason this exists -- needs the three
+ * files that describe ITS machine and not the four that are the same
+ * for everyone. Generating the shared ones beside the machine puts a
+ * second state_base.hpp on the include path, where it shadows the
+ * copy the rest of that project is built against.
+ */
+
+var assert = require('assert');
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var childProcess = require('child_process');
+
+var repoRoot = path.resolve(__dirname, '..');
+var CLI = path.join(repoRoot, 'bin/hfsm-gen.js');
+var MODEL = path.join(repoRoot, 'examples/Complex.json');
+
+function run(args) {
+  var out = fs.mkdtempSync(path.join(os.tmpdir(), 'hfsm-gen-'));
+  var r = childProcess.spawnSync(process.execPath,
+                                 [CLI, MODEL, '-o', out].concat(args || []),
+                                 { encoding: 'utf8' });
+  assert.strictEqual(r.status, 0,
+                     'hfsm-gen failed: ' + (r.stderr || r.stdout));
+  return { dir: out, files: fs.readdirSync(out).sort(), stderr: r.stderr };
+}
+
+describe('hfsm-gen --no-support', function() {
+  this.timeout(20000);
+
+  var full, lean;
+  before(function() {
+    full = run([]);
+    lean = run(['--no-support']);
+  });
+
+  it('leaves out the files that are the same for every machine', function() {
+    ['state_base.hpp', 'deep_history_state.hpp',
+     'shallow_history_state.hpp', 'magic_enum.hpp'].forEach(function(f) {
+      assert.ok(full.files.indexOf(f) > -1,
+                f + ' should be there by default');
+      assert.strictEqual(lean.files.indexOf(f), -1,
+                         f + ' should be gone with --no-support');
+    });
+  });
+
+  it('still emits everything about THIS machine', function() {
+    ['Complex_generated_states.hpp', 'Complex_generated_states.cpp',
+     'Complex_event_data.hpp'].forEach(function(f) {
+      assert.ok(lean.files.indexOf(f) > -1, f + ' must still be generated');
+    });
+  });
+
+  it('generates the same machine either way', function() {
+    // the flag decides what is WRITTEN, not what is rendered: a
+    // project switching to it should see no change in its own code
+    ['Complex_generated_states.hpp', 'Complex_generated_states.cpp',
+     'Complex_event_data.hpp'].forEach(function(f) {
+      assert.strictEqual(fs.readFileSync(path.join(lean.dir, f), 'utf8'),
+                         fs.readFileSync(path.join(full.dir, f), 'utf8'),
+                         f + ' should not depend on --no-support');
+    });
+  });
+
+  it('takes the list from the templates rather than a copy of it',
+     function() {
+    // if a support template is added, the flag has to drop it too --
+    // so the names come from the same table that renders them
+    var amdLoader = require('../bin/amd-loader');
+    return amdLoader.load([
+      'src/plugins/SoftwareGenerator/templates/MetaTemplates',
+    ]).then(function(loaded) {
+      var named = loaded[0].supportFileNames().sort();
+      var missing = full.files.filter(function(f) {
+        return lean.files.indexOf(f) === -1;
+      }).sort();
+      assert.deepStrictEqual(missing, named,
+        'the files the flag drops should be exactly the ones the ' +
+        'templates call support files');
+    });
+  });
+
+  it('says so when the test bench is asked for without them', function() {
+    // the bench builds standalone, and cannot without these: its
+    // Makefile stops at "'deep_history_state.hpp' file not found"
+    var r = run(['--no-support', '--test-bench']);
+    assert.match(r.stderr, /--no-support with --test-bench/,
+                 'should warn; stderr was: ' + r.stderr);
+  });
+});


### PR DESCRIPTION
The generator emits the machine **and** the small runtime it depends on — `state_base.hpp`, `deep_history_state.hpp`, `shallow_history_state.hpp`, `magic_enum.hpp`. Those four are identical for every machine.

A project that already carries that runtime wants the other three files and *not* these. [espp's `state_machine` component](https://github.com/esp-cpp/espp/tree/main/components/state_machine) is the motivating case: its copies are the adapted ones the rest of the codebase is built against, and a second `state_base.hpp` beside the generated machine lands on the include path and shadows them. Until now the only way to avoid that was to generate all eight files and delete four.

```sh
hfsm-gen my_machine.json -o generated --no-support
```

### Details worth knowing

- **The machine is byte-identical either way.** The flag decides what gets *written*, not what gets *rendered* — so a project switching to it sees no change in its own generated code. There's a test for exactly that.
- **The list is derived, not duplicated.** `--no-support` drops whatever `MetaTemplates.supportFileNames()` reports, and that comes from the same template tables that render them. A support template added later is dropped by the flag without anyone remembering to update a second list. Hardcoding the names in the CLI instead fails two tests.
- **`--test-bench` warns.** The bench is meant to build standalone and can't without those headers — I checked, its Makefile stops at `'deep_history_state.hpp' file not found` — so asking for both says so rather than quietly producing a bench that cannot build.

### Checks

294 → 299 tests, each mutation-tested. Goldens unchanged (the flag adds no output path), all six fixtures still compile under `-Werror` with sanitizers and their traces match, `verify:web` 72 files identical.